### PR TITLE
fotoapparat: Support API level 14

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/v2/surface/SetTextureBufferSizeTask.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/v2/surface/SetTextureBufferSizeTask.java
@@ -1,12 +1,15 @@
 package io.fotoapparat.hardware.v2.surface;
 
+import android.annotation.TargetApi;
 import android.graphics.SurfaceTexture;
+import android.os.Build;
 
 import io.fotoapparat.parameter.Size;
 
 /**
  * Sets the preview {@link Size} on a {@link SurfaceTexture}.
  */
+@TargetApi(Build.VERSION_CODES.LOLLIPOP)
 class SetTextureBufferSizeTask implements Runnable {
 
     private final SurfaceTexture surfaceTexture;

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 androidBuildToolsVersion=2.3.2
 buildToolsVersion=25.0.2
 compileSdkVersion=25
-minSdkVersion=15
+minSdkVersion=14
 targetSdkVersion=25
 
 


### PR DESCRIPTION
15 is already supported, and 14 isn't much different. The only call that
surfaced lint errors is only used on api 21 or above for camera 2.