### PR TITLE
Use device orientation instead of system orientation for image rotation calculations

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/CameraDevice.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/CameraDevice.java
@@ -49,7 +49,7 @@ public interface CameraDevice extends CaptureOperator,
     void setDisplaySurface(Object displaySurface);
 
     @Override
-    void setDisplayOrientation(int degrees);
+    void setDisplayOrientation(int degrees, int orientation);
 
     @Override
     void updateParameters(Parameters parameters);

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/operators/OrientationOperator.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/operators/OrientationOperator.java
@@ -9,5 +9,5 @@ public interface OrientationOperator {
     /**
      * Sets the current orientation of the display.
      */
-    void setDisplayOrientation(int degrees);
+    void setDisplayOrientation(int degrees, int orientation);
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/orientation/OrientationSensor.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/orientation/OrientationSensor.java
@@ -11,6 +11,7 @@ public class OrientationSensor implements RotationListener.Listener {
     private final ScreenOrientationProvider screenOrientationProvider;
 
     private int lastKnownRotation;
+    private int lastKnownOrientation;
     private Listener listener;
 
     public OrientationSensor(@NonNull final RotationListener rotationListener,
@@ -38,12 +39,15 @@ public class OrientationSensor implements RotationListener.Listener {
     }
 
     @Override
-    public void onRotationChanged() {
+    public void onRotationChanged(int newOrientation) {
         if (listener != null) {
-            int rotation = screenOrientationProvider.getScreenRotation();
-            if (rotation != lastKnownRotation) {
-                listener.onOrientationChanged(rotation);
+            // reduce orientation to multiple of 90
+            int orientation = ((newOrientation + 45) / 90 * 90) % 360;
+            int rotation = this.screenOrientationProvider.getScreenRotation();
+            if (rotation != lastKnownRotation || orientation != lastKnownOrientation) {
+                listener.onOrientationChanged(rotation, orientation);
                 lastKnownRotation = rotation;
+                lastKnownOrientation = orientation;
             }
         }
     }
@@ -56,6 +60,6 @@ public class OrientationSensor implements RotationListener.Listener {
         /**
          * Called when orientation of the device is updated.
          */
-        void onOrientationChanged(int degrees);
+        void onOrientationChanged(int degrees, int orientation);
     }
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/orientation/OrientationSensor.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/orientation/OrientationSensor.java
@@ -1,6 +1,7 @@
 package io.fotoapparat.hardware.orientation;
 
 import android.support.annotation.NonNull;
+import android.view.OrientationEventListener;
 
 /**
  * Monitors orientation of the device.
@@ -11,14 +12,14 @@ public class OrientationSensor implements RotationListener.Listener {
     private final ScreenOrientationProvider screenOrientationProvider;
 
     private int lastKnownRotation;
-    private int lastKnownOrientation;
+    private int lastKnownOrientation = OrientationEventListener.ORIENTATION_UNKNOWN;
     private Listener listener;
 
     public OrientationSensor(@NonNull final RotationListener rotationListener,
                              @NonNull final ScreenOrientationProvider screenOrientationProvider) {
         this.rotationListener = rotationListener;
         this.screenOrientationProvider = screenOrientationProvider;
-
+        this.lastKnownRotation = screenOrientationProvider.getScreenRotation();
         rotationListener.setRotationListener(this);
     }
 

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/orientation/OrientationUtils.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/orientation/OrientationUtils.java
@@ -1,5 +1,7 @@
 package io.fotoapparat.hardware.orientation;
 
+import static android.view.OrientationEventListener.ORIENTATION_UNKNOWN;
+
 /**
  * Utilities for working with device orientation.
  */
@@ -47,7 +49,7 @@ public class OrientationUtils {
      *                              for front cameras). {@code false} if it is not mirrored.
      * @return clockwise rotation of the image relatively to current device orientation.
      */
-    public static int computeImageOrientation(int screenRotationDegrees,
+    public static int computePreviewOrientation(int screenRotationDegrees,
                                               int cameraRotationDegrees,
                                               boolean cameraIsMirrored) {
         int rotation;
@@ -61,4 +63,25 @@ public class OrientationUtils {
         return (rotation + 360 + 360) % 360;
     }
 
+    /**
+     * Copied from {@link android.hardware.Camera.Parameters#setRotation(int)}
+     * @param screenOrientationDegrees rotation of the display (as provided by an {@link android.view.OrientationEventListener}) in degrees.
+     * @param cameraRotationDegrees rotation of the camera sensor relatively to device natural
+     *                              orientation.
+     * @param cameraIsMirrored      {@code true} if camera is mirrored (typically that is the case
+     *                              for front cameras). {@code false} if it is not mirrored.
+     * @return clockwise rotation of the image relatively to current device orientation.
+     */
+    public static int computeImageOrientation(int screenOrientationDegrees,
+                                                int cameraRotationDegrees,
+                                                boolean cameraIsMirrored) {
+        if (screenOrientationDegrees == ORIENTATION_UNKNOWN) return screenOrientationDegrees;
+        int rotation = 0;
+        if (cameraIsMirrored) {
+            rotation = (cameraRotationDegrees - screenOrientationDegrees + 360) % 360;
+        } else {  // back-facing camera
+            rotation = (cameraRotationDegrees + screenOrientationDegrees) % 360;
+        }
+        return rotation;
+    }
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/orientation/OrientationUtils.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/orientation/OrientationUtils.java
@@ -75,13 +75,13 @@ public class OrientationUtils {
     public static int computeImageOrientation(int screenOrientationDegrees,
                                                 int cameraRotationDegrees,
                                                 boolean cameraIsMirrored) {
-        if (screenOrientationDegrees == ORIENTATION_UNKNOWN) return screenOrientationDegrees;
-        int rotation = 0;
+        if (screenOrientationDegrees == ORIENTATION_UNKNOWN) return 360 - screenOrientationDegrees;
+        int rotation;
         if (cameraIsMirrored) {
             rotation = (cameraRotationDegrees - screenOrientationDegrees + 360) % 360;
         } else {  // back-facing camera
             rotation = (cameraRotationDegrees + screenOrientationDegrees) % 360;
         }
-        return rotation;
+        return 360 - rotation;
     }
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/orientation/RotationListener.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/orientation/RotationListener.java
@@ -18,7 +18,7 @@ public class RotationListener extends OrientationEventListener {
     @Override
     public void onOrientationChanged(int orientation) {
         if (listener != null && canDetectOrientation()) {
-            listener.onRotationChanged();
+            listener.onRotationChanged(orientation);
         }
     }
 
@@ -38,7 +38,8 @@ public class RotationListener extends OrientationEventListener {
 
         /**
          * Called when the rotation of the device has changed.
+         * @param orientation
          */
-        void onRotationChanged();
+        void onRotationChanged(int orientation);
     }
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/v2/Camera2.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/v2/Camera2.java
@@ -111,10 +111,10 @@ public class Camera2 implements CameraDevice {
     }
 
     @Override
-    public void setDisplayOrientation(int degrees) {
+    public void setDisplayOrientation(int degrees, int orientation) {
         recordMethod();
 
-        orientationOperator.setDisplayOrientation(degrees);
+        orientationOperator.setDisplayOrientation(degrees, orientation);
     }
 
     @Override

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/v2/orientation/OrientationManager.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/v2/orientation/OrientationManager.java
@@ -19,7 +19,7 @@ public class OrientationManager implements OrientationOperator {
 
     private final List<Listener> listeners = new ArrayList<>();
     private final CameraConnection cameraConnection;
-    private int orientation;
+    private int rotation;
 
     public OrientationManager(CameraConnection cameraConnection) {
         this.cameraConnection = cameraConnection;
@@ -28,13 +28,13 @@ public class OrientationManager implements OrientationOperator {
     /**
      * Notifies that the display orientation has changed.
      *
-     * @param orientation the display orientation in degrees. One of: 0, 90, 180 and 270
+     * @param rotation the display rotation in degrees. One of: 0, 90, 180 and 270
      */
     @Override
-    public void setDisplayOrientation(int orientation) {
-        this.orientation = orientation;
+    public void setDisplayOrientation(int rotation, int orientation) {
+        this.rotation = rotation;
         for (Listener listener : listeners) {
-            listener.onDisplayOrientationChanged(orientation);
+            listener.onDisplayOrientationChanged(rotation, orientation);
         }
     }
 
@@ -45,8 +45,8 @@ public class OrientationManager implements OrientationOperator {
     public int getPhotoOrientation() {
         Characteristics characteristics = cameraConnection.getCharacteristics();
 
-        return OrientationUtils.computeImageOrientation(
-                orientation,
+        return OrientationUtils.computePreviewOrientation(
+                rotation,
                 characteristics.getSensorOrientation(),
                 characteristics.isFrontFacingLens()
         );
@@ -72,8 +72,8 @@ public class OrientationManager implements OrientationOperator {
         /**
          * Called when the display orientation has changed.
          *
-         * @param orientation the display orientation in degrees. One of: 0, 90, 180 and 270
+         * @param rotation the display orientation in degrees. One of: 0, 90, 180 and 270
          */
-        void onDisplayOrientationChanged(int orientation);
+        void onDisplayOrientationChanged(int rotation, int orientation);
     }
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/v2/surface/TextureManager.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/v2/surface/TextureManager.java
@@ -30,8 +30,8 @@ public class TextureManager
     }
 
     @Override
-    public void onDisplayOrientationChanged(int orientation) {
-        screenOrientation = orientation;
+    public void onDisplayOrientationChanged(int rotation, int orientation) {
+        screenOrientation = rotation;
 
         if (textureView == null) {
             return;

--- a/fotoapparat/src/main/java/io/fotoapparat/routine/StartCameraRoutine.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/routine/StartCameraRoutine.java
@@ -1,5 +1,7 @@
 package io.fotoapparat.routine;
 
+import android.view.OrientationEventListener;
+
 import io.fotoapparat.error.CameraErrorCallback;
 import io.fotoapparat.hardware.CameraDevice;
 import io.fotoapparat.hardware.CameraException;
@@ -9,6 +11,8 @@ import io.fotoapparat.parameter.ScaleType;
 import io.fotoapparat.parameter.provider.InitialParametersProvider;
 import io.fotoapparat.parameter.selector.SelectorFunction;
 import io.fotoapparat.view.CameraRenderer;
+
+import static android.view.OrientationEventListener.ORIENTATION_UNKNOWN;
 
 /**
  * Opens camera and starts preview.
@@ -58,7 +62,7 @@ public class StartCameraRoutine implements Runnable {
                 initialParametersProvider.initialParameters()
         );
         cameraDevice.setDisplayOrientation(
-                screenOrientationProvider.getScreenRotation()
+                screenOrientationProvider.getScreenRotation(), ORIENTATION_UNKNOWN
         );
         cameraRenderer.setScaleType(scaleType);
         cameraRenderer.attachCamera(cameraDevice);

--- a/fotoapparat/src/main/java/io/fotoapparat/routine/UpdateOrientationRoutine.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/routine/UpdateOrientationRoutine.java
@@ -37,11 +37,11 @@ public class UpdateOrientationRoutine implements OrientationSensor.Listener {
     }
 
     @Override
-    public void onOrientationChanged(final int degrees) {
+    public void onOrientationChanged(final int degrees, final int orientation) {
         cameraExecutor.execute(new Runnable() {
             @Override
             public void run() {
-                cameraDevice.setDisplayOrientation(degrees);
+                cameraDevice.setDisplayOrientation(degrees, orientation);
             }
         });
     }

--- a/fotoapparat/src/test/java/io/fotoapparat/hardware/orientation/OrientationSensorTest.java
+++ b/fotoapparat/src/test/java/io/fotoapparat/hardware/orientation/OrientationSensorTest.java
@@ -48,18 +48,21 @@ public class OrientationSensorTest {
         // Given
         given(screenOrientationProvider.getScreenRotation())
                 .willReturn(90);
-        final AtomicInteger atomicInteger = new AtomicInteger();
+        final AtomicInteger atomicDegrees = new AtomicInteger();
+        final AtomicInteger atomicOrientation = new AtomicInteger();
         testee.start(new OrientationSensor.Listener() {
             @Override
-            public void onOrientationChanged(int degrees) {
-                atomicInteger.set(degrees);
+            public void onOrientationChanged(int degrees, int orientation) {
+                atomicDegrees.set(degrees);
+                atomicOrientation.set(orientation);
             }
         });
 
         // When
-        testee.onRotationChanged();
+        testee.onRotationChanged(180);
 
         // Then
-        assertEquals(90, atomicInteger.get());
+        assertEquals(90, atomicDegrees.get());
+        assertEquals(180, atomicOrientation.get());
     }
 }

--- a/fotoapparat/src/test/java/io/fotoapparat/hardware/orientation/OrientationUtilsTest.java
+++ b/fotoapparat/src/test/java/io/fotoapparat/hardware/orientation/OrientationUtilsTest.java
@@ -121,7 +121,7 @@ public class OrientationUtilsTest {
         int cameraOrientation = 270;
 
         // When
-        int result = OrientationUtils.computeImageOrientation(
+        int result = OrientationUtils.computePreviewOrientation(
                 screenOrientation,
                 cameraOrientation,
                 true
@@ -138,7 +138,7 @@ public class OrientationUtilsTest {
         int cameraOrientation = 270;
 
         // When
-        int result = OrientationUtils.computeImageOrientation(
+        int result = OrientationUtils.computePreviewOrientation(
                 screenOrientation,
                 cameraOrientation,
                 true
@@ -155,7 +155,7 @@ public class OrientationUtilsTest {
         int cameraOrientation = 90;
 
         // When
-        int result = OrientationUtils.computeImageOrientation(
+        int result = OrientationUtils.computePreviewOrientation(
                 screenOrientation,
                 cameraOrientation,
                 false
@@ -172,7 +172,7 @@ public class OrientationUtilsTest {
         int cameraOrientation = 90;
 
         // When
-        int result = OrientationUtils.computeImageOrientation(
+        int result = OrientationUtils.computePreviewOrientation(
                 screenOrientation,
                 cameraOrientation,
                 false

--- a/fotoapparat/src/test/java/io/fotoapparat/hardware/v2/Camera2Test.java
+++ b/fotoapparat/src/test/java/io/fotoapparat/hardware/v2/Camera2Test.java
@@ -131,11 +131,11 @@ public class Camera2Test {
     @Test
     public void setDisplayOrientation() throws Exception {
         // When
-        testee.setDisplayOrientation(90);
+        testee.setDisplayOrientation(90, 90);
 
         // Then
         verify(logger).log(anyString());
-        verify(orientationOperator).setDisplayOrientation(90);
+        verify(orientationOperator).setDisplayOrientation(90, 90);
     }
 
     @Test

--- a/fotoapparat/src/test/java/io/fotoapparat/hardware/v2/orientation/OrientationManagerTest.java
+++ b/fotoapparat/src/test/java/io/fotoapparat/hardware/v2/orientation/OrientationManagerTest.java
@@ -9,6 +9,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import io.fotoapparat.hardware.v2.connection.CameraConnection;
 
+import static android.view.OrientationEventListener.ORIENTATION_UNKNOWN;
 import static junit.framework.Assert.assertEquals;
 import static org.mockito.BDDMockito.given;
 
@@ -145,18 +146,18 @@ public class OrientationManagerTest {
     }
 
     private void givenPortraitScreen() {
-        testee.setDisplayOrientation(PORTRAIT_DEGREES);
+        testee.setDisplayOrientation(PORTRAIT_DEGREES, ORIENTATION_UNKNOWN);
     }
 
     private void givenLandscapeScreen() {
-        testee.setDisplayOrientation(LANDSCAPE_DEGREES);
+        testee.setDisplayOrientation(LANDSCAPE_DEGREES, ORIENTATION_UNKNOWN);
     }
 
     private void givenReversePortraitScreen() {
-        testee.setDisplayOrientation(REVERSE_PORTRAIT_DEGREES);
+        testee.setDisplayOrientation(REVERSE_PORTRAIT_DEGREES, ORIENTATION_UNKNOWN);
     }
 
     private void givenReverseLandscapeScreen() {
-        testee.setDisplayOrientation(REVERSE_LANDSCAPE_DEGREES);
+        testee.setDisplayOrientation(REVERSE_LANDSCAPE_DEGREES, ORIENTATION_UNKNOWN);
     }
 }

--- a/fotoapparat/src/test/java/io/fotoapparat/routine/StartCameraRoutineTest.java
+++ b/fotoapparat/src/test/java/io/fotoapparat/routine/StartCameraRoutineTest.java
@@ -21,6 +21,7 @@ import io.fotoapparat.parameter.provider.InitialParametersProvider;
 import io.fotoapparat.parameter.selector.SelectorFunction;
 import io.fotoapparat.view.CameraRenderer;
 
+import static android.view.OrientationEventListener.ORIENTATION_UNKNOWN;
 import static java.util.Arrays.asList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
@@ -104,7 +105,7 @@ public class StartCameraRoutineTest {
         inOrder.verify(lensPositionSelector).select(availableLensPositions);
         inOrder.verify(cameraDevice).open(preferredLensPosition);
         inOrder.verify(cameraDevice).updateParameters(INITIAL_PARAMETERS);
-        inOrder.verify(cameraDevice).setDisplayOrientation(SCREEN_ROTATION_DEGREES);
+        inOrder.verify(cameraDevice).setDisplayOrientation(SCREEN_ROTATION_DEGREES, ORIENTATION_UNKNOWN);
         inOrder.verify(cameraRenderer).setScaleType(scaleType);
         inOrder.verify(cameraRenderer).attachCamera(cameraDevice);
         inOrder.verify(cameraDevice).startPreview();

--- a/fotoapparat/src/test/java/io/fotoapparat/routine/UpdateOrientationRoutineTest.java
+++ b/fotoapparat/src/test/java/io/fotoapparat/routine/UpdateOrientationRoutineTest.java
@@ -52,9 +52,9 @@ public class UpdateOrientationRoutineTest {
     @Test
     public void onOrientationChanged() throws Exception {
         // When
-        testee.onOrientationChanged(90);
+        testee.onOrientationChanged(90, 90);
 
         // Then
-        verify(cameraDevice).setDisplayOrientation(90);
+        verify(cameraDevice).setDisplayOrientation(90, 90);
     }
 }


### PR DESCRIPTION
Previously the image rotation was being calculated from the system orientation, which meant if a device was locked into portrait and the device was rotated landscape (i.e. system orientation != device orientation) the resulting photo would be rotated incorrectly.

The system orientation is still required to calculate rotation for the preview view and has not be removed. The only change is the calculation of image rotation.