### PR TITLE
Add isStarted() to Fotoapparat

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/Fotoapparat.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/Fotoapparat.java
@@ -184,6 +184,13 @@ public class Fotoapparat {
     }
 
     /**
+     * @return {@code true} if camera is started, {@code false} otherwise.
+     */
+    public boolean isStarted() {
+        return started;
+    }
+
+    /**
      * Provides camera capabilities asynchronously, returns immediately.
      *
      * @return {@link CapabilitiesResult} which will deliver result asynchronously.

--- a/fotoapparat/src/test/java/io/fotoapparat/FotoapparatTest.java
+++ b/fotoapparat/src/test/java/io/fotoapparat/FotoapparatTest.java
@@ -107,6 +107,8 @@ public class FotoapparatTest {
                 configurePreviewStreamRoutine
         );
 
+        assertTrue(testee.isStarted());
+
         inOrder.verify(startCameraRoutine).run();
         inOrder.verify(configurePreviewStreamRoutine).run();
         inOrder.verify(updateOrientationRoutine).start();
@@ -133,6 +135,8 @@ public class FotoapparatTest {
         testee.stop();
 
         // Then
+        assertFalse(testee.isStarted());
+
         InOrder inOrder = inOrder(
                 stopCameraRoutine,
                 updateOrientationRoutine


### PR DESCRIPTION
Sometimes we want to check if camera is started.

The main use case is to support LiveData updates with new camera properties.
Those updates can fire before camera is started and this case must be detected.