### PR TITLE
Aspect ratio selector with tolerance

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/selector/AspectRatioSelectors.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/selector/AspectRatioSelectors.java
@@ -19,6 +19,16 @@ public class AspectRatioSelectors {
     }
 
     /**
+     * @param selector Input selector
+     * @param tolerance Aspect ratio tolerance (0.0 - 1.0)
+     *
+     * @return {@link SelectorFunction} which selects some size around standard aspect ratio (4:3), with given tolerance.
+     */
+    public static SelectorFunction<Size> standardRatio(SelectorFunction<Size> selector, double tolerance) {
+        return aspectRatio(4f / 3f, selector, tolerance);
+    }
+
+    /**
      * @return {@link SelectorFunction} which selects some size of wide aspect ratio (16:9).
      */
     public static SelectorFunction<Size> wideRatio(SelectorFunction<Size> selector) {
@@ -26,28 +36,61 @@ public class AspectRatioSelectors {
     }
 
     /**
+     * @param selector Input sizes, selected by provided selector function
+     * @param tolerance Aspect ratio tolerance in range of 0.0 (0%) to 1.0 (100%)
+     *
+     * @return {@link SelectorFunction} which selects some size around wide aspect ratio (16:9), with given tolerance.
+     */
+    public static SelectorFunction<Size> wideRatio(SelectorFunction<Size> selector, double tolerance) {
+        return aspectRatio(16f / 9f, selector, tolerance);
+    }
+
+    /**
+     * Select sizes with desired aspect ratio. This selector can
+     * select sizes that differ slightly from ideal aspect ratio.
+     *
+     * @param aspectRatio Desired aspect ratio
+     * @param tolerance Aspect ratio tolerance, as 0.0 - 1.0, where 0 is exact aspect ratio and 1 allows 100% deviation
+     *
+     * @return {@link SelectorFunction} which selects some size around given aspect ratio.
+     */
+    public static SelectorFunction<Size> aspectRatio(float aspectRatio, SelectorFunction<Size> selector, double tolerance) {
+        return Selectors.filtered(
+                selector,
+                new AspectRatioPredicate(aspectRatio, tolerance)
+        );
+    }
+
+    /**
+     * Select sizes with desired, exact aspect ratio.
+     *
      * @return {@link SelectorFunction} which selects some size of given aspect ratio.
      */
     public static SelectorFunction<Size> aspectRatio(float aspectRatio,
                                                      SelectorFunction<Size> selector) {
         return Selectors.filtered(
                 selector,
-                new AspectRatioPredicate(aspectRatio)
+                new AspectRatioPredicate(aspectRatio, 0.0)
         );
     }
 
     private static class AspectRatioPredicate implements Predicate<Size> {
 
         private final float aspectRatio;
+        private final double tolerance;
 
-        private AspectRatioPredicate(float aspectRatio) {
+        private AspectRatioPredicate(float aspectRatio, double tolerance) {
+            if(tolerance < 0.0 || tolerance > 1.0) {
+                throw new IllegalArgumentException("Tolerance must be in .0 - 1.0 range");
+            }
             this.aspectRatio = aspectRatio;
+            this.tolerance = (aspectRatio * tolerance) + ASPECT_RATIO_EPSILON;
         }
 
         @Override
         public boolean condition(@Nullable Size value) {
             return value != null
-                    && Math.abs(aspectRatio - value.getAspectRatio()) < ASPECT_RATIO_EPSILON;
+                    && Math.abs(aspectRatio - value.getAspectRatio()) <= tolerance;
 
         }
 

--- a/fotoapparat/src/test/java/io/fotoapparat/parameter/selector/AspectRatioSelectorsTest.java
+++ b/fotoapparat/src/test/java/io/fotoapparat/parameter/selector/AspectRatioSelectorsTest.java
@@ -48,6 +48,38 @@ public class AspectRatioSelectorsTest {
     }
 
     @Test
+    public void standardRatioWithTolerance() throws Exception {
+        // Given
+        given(sizeSelector.select(ArgumentMatchers.<Size>anyCollection()))
+                .willReturn(new Size(400, 300));
+
+        // When
+        Size result = AspectRatioSelectors
+                .standardRatio(sizeSelector, 0.1)
+                .select(asList(
+                        new Size(400, 300),
+                        new Size(410, 300),
+                        new Size(800, 600),
+                        new Size(790, 600),
+                        new Size(100, 100),
+                        new Size(160, 90)
+                ));
+
+        // Then
+        assertEquals(
+                new Size(400, 300),
+                result
+        );
+
+        verify(sizeSelector).select(asSet(
+                new Size(400, 300),
+                new Size(410, 300),
+                new Size(800, 600),
+                new Size(790, 600)
+        ));
+    }
+
+    @Test
     public void wideRatio() throws Exception {
         // Given
         given(sizeSelector.select(ArgumentMatchers.<Size>anyCollection()))
@@ -71,6 +103,70 @@ public class AspectRatioSelectorsTest {
         verify(sizeSelector).select(asSet(
                 new Size(16, 9),
                 new Size(32, 18)
+        ));
+    }
+
+    @Test
+    public void wideRatioWithTolerance() throws Exception {
+        // Given
+        given(sizeSelector.select(ArgumentMatchers.<Size>anyCollection()))
+                .willReturn(new Size(16, 9));
+
+        // When
+        Size result = AspectRatioSelectors
+                .wideRatio(sizeSelector, 0.1)
+                .select(asList(
+                        new Size(16, 9),
+                        new Size(16, 10),
+                        new Size(32, 18),
+                        new Size(32, 20),
+                        new Size(10, 10)
+                ));
+
+        // Then
+        assertEquals(
+                new Size(16, 9),
+                result
+        );
+
+        verify(sizeSelector).select(asSet(
+                new Size(16, 9),
+                new Size(16, 10),
+                new Size(32, 18),
+                new Size(32, 20)
+        ));
+    }
+
+    @Test
+    public void ratioWithTolerance() throws Exception {
+        // Given
+        given(sizeSelector.select(ArgumentMatchers.<Size>anyCollection()))
+                .willReturn(new Size(110, 100));
+
+        // When
+        Size result = AspectRatioSelectors
+                .aspectRatio(1.0f, sizeSelector, 0.1)
+                .select(asList(
+                        new Size(16, 9),
+                        new Size(110, 100),
+                        new Size(105, 100),
+                        new Size(95, 100),
+                        new Size(90, 100),
+                        new Size(4, 3),
+                        new Size(20, 10)
+                ));
+
+        // Then
+        assertEquals(
+                new Size(110, 100),
+                result
+        );
+
+        verify(sizeSelector).select(asSet(
+                new Size(110, 100),
+                new Size(105, 100),
+                new Size(95, 100),
+                new Size(90, 100)
         ));
     }
 

--- a/fotoapparat/src/test/java/io/fotoapparat/parameter/selector/AspectRatioSelectorsTest.java
+++ b/fotoapparat/src/test/java/io/fotoapparat/parameter/selector/AspectRatioSelectorsTest.java
@@ -11,6 +11,7 @@ import io.fotoapparat.parameter.Size;
 import static io.fotoapparat.test.TestUtils.asSet;
 import static java.util.Arrays.asList;
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.fail;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -170,4 +171,35 @@ public class AspectRatioSelectorsTest {
         ));
     }
 
+    @Test
+    public void ratioWithNegativeToleranceThrows() throws Exception {
+        // Given
+        final double NEGATIVE_TOLERANCE = -0.1;
+        final double ABOVE_RANGE_TOLERANCE = 1.1;
+
+        try {
+            // When
+            AspectRatioSelectors
+                    .aspectRatio(1.0f, sizeSelector, NEGATIVE_TOLERANCE)
+                    .select(asList(
+                            new Size(16, 9),
+                            new Size(16, 10)));
+            fail("Negative aspect ratio tolerance is illegal");
+        } catch (IllegalArgumentException ex) {
+            // Then exception is throws
+        }
+
+
+        try {
+            // When
+            AspectRatioSelectors
+                    .aspectRatio(1.0f, sizeSelector, ABOVE_RANGE_TOLERANCE)
+                    .select(asList(
+                            new Size(16, 9),
+                            new Size(16, 10)));
+            fail("Aspect ratio tolerance >1.0 is illegal");
+        } catch (IllegalArgumentException ex) {
+            // Then exception is throws
+        }
+    }
 }


### PR DESCRIPTION
Some resolutions supported by camera CCD have aspect ratios
that deviate from 16:9 and 4:3 by a small margin (ex. 16:10).

Add tolerance to aspect ratio selector to catch all picture
sizses that would be otherwise rejected due to strict
comparison.