### PR TITLE
add JpegQuality parameter

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/Fotoapparat.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/Fotoapparat.java
@@ -13,7 +13,6 @@ import io.fotoapparat.hardware.CameraDevice;
 import io.fotoapparat.hardware.orientation.OrientationSensor;
 import io.fotoapparat.hardware.orientation.RotationListener;
 import io.fotoapparat.hardware.orientation.ScreenOrientationProvider;
-import io.fotoapparat.parameter.Parameters;
 import io.fotoapparat.parameter.provider.CapabilitiesProvider;
 import io.fotoapparat.parameter.provider.CurrentParametersProvider;
 import io.fotoapparat.parameter.provider.InitialParametersProvider;
@@ -109,6 +108,7 @@ public class Fotoapparat {
                 builder.flashSelector,
                 builder.previewFpsRangeSelector,
                 builder.sensorSensitivitySelector,
+                builder.jpegQuality,
                 parametersValidator
         );
 

--- a/fotoapparat/src/main/java/io/fotoapparat/FotoapparatBuilder.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/FotoapparatBuilder.java
@@ -19,7 +19,6 @@ import io.fotoapparat.parameter.range.Range;
 import io.fotoapparat.parameter.selector.FlashSelectors;
 import io.fotoapparat.parameter.selector.SelectorFunction;
 import io.fotoapparat.parameter.selector.Selectors;
-import io.fotoapparat.parameter.selector.SensorSensitivitySelectors;
 import io.fotoapparat.preview.FrameProcessor;
 import io.fotoapparat.view.CameraRenderer;
 import io.fotoapparat.view.CameraView;
@@ -58,6 +57,8 @@ public class FotoapparatBuilder {
     SelectorFunction<Collection<Flash>, Flash> flashSelector = FlashSelectors.off();
     SelectorFunction<Collection<Range<Integer>>, Range<Integer>> previewFpsRangeSelector = Selectors.nothing();
     SelectorFunction<Range<Integer>, Integer> sensorSensitivitySelector = Selectors.nothing();
+
+    Integer jpegQuality;
 
     ScaleType scaleType = ScaleType.CENTER_CROP;
 
@@ -140,6 +141,14 @@ public class FotoapparatBuilder {
      */
     public FotoapparatBuilder sensorSensitivity(@NonNull SelectorFunction<Range<Integer>, Integer> selector) {
         sensorSensitivitySelector = selector;
+        return this;
+    }
+
+    /**
+     * @param jpegQuality of the picture (1-100)
+     */
+    public FotoapparatBuilder jpegQuality(@NonNull Integer jpegQuality) {
+        this.jpegQuality = jpegQuality;
         return this;
     }
 

--- a/fotoapparat/src/main/java/io/fotoapparat/FotoapparatBuilder.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/FotoapparatBuilder.java
@@ -1,6 +1,7 @@
 package io.fotoapparat;
 
 import android.content.Context;
+import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
 
 import io.fotoapparat.error.CameraErrorCallback;
@@ -147,7 +148,7 @@ public class FotoapparatBuilder {
     /**
      * @param jpegQuality of the picture (1-100)
      */
-    public FotoapparatBuilder jpegQuality(@NonNull Integer jpegQuality) {
+    public FotoapparatBuilder jpegQuality(@IntRange(from=0,to=100) @NonNull Integer jpegQuality) {
         this.jpegQuality = jpegQuality;
         return this;
     }

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/v1/CameraParametersDecorator.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/v1/CameraParametersDecorator.java
@@ -163,6 +163,21 @@ public class CameraParametersDecorator {
         }
     }
 
+    /**
+     * @see Camera.Parameters#getJpegQuality()
+     */
+    public int getJpegQuality(){
+        return cameraParameters.getJpegQuality();
+    }
+
+    /**
+     * @see Camera.Parameters#setJpegQuality(int)
+     */
+    public void setJpegQuality(int quality){
+        cameraParameters.setJpegQuality(quality);
+    }
+
+
     @Nullable
     private String findExistingKey(@NonNull String[] keys) {
         for (String key : keys) {

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/v1/ParametersConverter.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/v1/ParametersConverter.java
@@ -59,6 +59,9 @@ public class ParametersConverter {
         Size previewSize = new Size(platformPreviewSize.width, platformPreviewSize.height);
         parameters.putValue(Parameters.Type.PREVIEW_SIZE, previewSize);
 
+        Integer jpegQuality = platformParameters.getJpegQuality();
+        parameters.putValue(Parameters.Type.JPEG_QUALITY, jpegQuality);
+
         return parameters;
     }
 
@@ -102,6 +105,10 @@ public class ParametersConverter {
                         output
                 );
                 break;
+            case JPEG_QUALITY:
+                applyJpegQuality(
+                        (Integer) input.getValue(type),
+                        output);
         }
     }
 
@@ -144,6 +151,11 @@ public class ParametersConverter {
     private void applySensorSensitivity(Integer value,
                                         CameraParametersDecorator output) {
         output.setSensorSensitivityValue(value);
+    }
+
+    private void applyJpegQuality(Integer value,
+                                  CameraParametersDecorator output){
+        output.setJpegQuality(value);
     }
 
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/v2/parameters/CaptureRequestBuilder.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/v2/parameters/CaptureRequestBuilder.java
@@ -32,6 +32,7 @@ class CaptureRequestBuilder {
     boolean cancelPrecaptureExposure;
     boolean shouldSetExposureMode;
     Integer sensorSensitivity;
+    Integer jpegQuality;
 
     private CaptureRequestBuilder(CameraDevice cameraDevice, @RequestTemplate int requestTemplate) {
         this.cameraDevice = cameraDevice;
@@ -97,6 +98,11 @@ class CaptureRequestBuilder {
 
     CaptureRequestBuilder sensorSensitivity(Integer sensorSensitivity) {
         this.sensorSensitivity = sensorSensitivity;
+        return this;
+    }
+
+    CaptureRequestBuilder jpegQuality(Integer jpegQuality) {
+        this.jpegQuality = jpegQuality;
         return this;
     }
 

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/v2/parameters/CaptureRequestFactory.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/v2/parameters/CaptureRequestFactory.java
@@ -48,6 +48,7 @@ public class CaptureRequestFactory {
         Flash flash = parametersProvider.getFlash();
         Range<Integer> previewFpsRange = parametersProvider.getPreviewFpsRange();
         Integer sensorSensitivity = parametersProvider.getSensorSensitivity();
+        Integer jpegQuality = parametersProvider.getJpegQuality();
 
         return CaptureRequestBuilder
                 .create(camera, CameraDevice.TEMPLATE_PREVIEW)
@@ -55,6 +56,7 @@ public class CaptureRequestFactory {
                 .flash(flash)
                 .previewFpsRange(previewFpsRange)
                 .sensorSensitivity(sensorSensitivity)
+                .jpegQuality(jpegQuality)
                 .build();
     }
 
@@ -72,6 +74,7 @@ public class CaptureRequestFactory {
         Range<Integer> previewFpsRange = parametersProvider.getPreviewFpsRange();
         boolean triggerAutoExposure = !cameraConnection.getCharacteristics().isLegacyDevice();
         Integer sensorSensitivity = parametersProvider.getSensorSensitivity();
+        Integer jpegQuality = parametersProvider.getJpegQuality();
 
         return CaptureRequestBuilder
                 .create(camera, CameraDevice.TEMPLATE_STILL_CAPTURE)
@@ -81,6 +84,7 @@ public class CaptureRequestFactory {
                 .triggerAutoFocus(true)
                 .triggerPrecaptureExposure(triggerAutoExposure)
                 .sensorSensitivity(sensorSensitivity)
+                .jpegQuality(jpegQuality)
                 .build();
     }
 
@@ -98,6 +102,7 @@ public class CaptureRequestFactory {
         FocusMode focus = parametersProvider.getFocus();
         Range<Integer> previewFpsRange = parametersProvider.getPreviewFpsRange();
         Integer sensorSensitivity = parametersProvider.getSensorSensitivity();
+        Integer jpegQuality = parametersProvider.getJpegQuality();
 
         boolean triggerPrecaptureExposure = !cameraConnection.getCharacteristics().isLegacyDevice();
 
@@ -110,6 +115,7 @@ public class CaptureRequestFactory {
                 .previewFpsRange(previewFpsRange)
                 .setExposureMode(true)
                 .sensorSensitivity(sensorSensitivity)
+                .jpegQuality(jpegQuality)
                 .build();
     }
 
@@ -125,6 +131,7 @@ public class CaptureRequestFactory {
         FocusMode focus = parametersProvider.getFocus();
         Range<Integer> previewFpsRange = parametersProvider.getPreviewFpsRange();
         Integer sensorSensitivity = parametersProvider.getSensorSensitivity();
+        Integer jpegQuality = parametersProvider.getJpegQuality();
 
         return CaptureRequestBuilder
                 .create(camera, CameraDevice.TEMPLATE_STILL_CAPTURE)
@@ -134,6 +141,7 @@ public class CaptureRequestFactory {
                 .focus(focus)
                 .previewFpsRange(previewFpsRange)
                 .sensorSensitivity(sensorSensitivity)
+                .jpegQuality(jpegQuality)
                 .setExposureMode(true)
                 .build();
     }

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/v2/parameters/ParametersProvider.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/v2/parameters/ParametersProvider.java
@@ -11,6 +11,7 @@ import io.fotoapparat.parameter.range.Range;
 
 import static io.fotoapparat.parameter.Parameters.Type.FLASH;
 import static io.fotoapparat.parameter.Parameters.Type.FOCUS_MODE;
+import static io.fotoapparat.parameter.Parameters.Type.JPEG_QUALITY;
 import static io.fotoapparat.parameter.Parameters.Type.PICTURE_SIZE;
 import static io.fotoapparat.parameter.Parameters.Type.PREVIEW_FPS_RANGE;
 import static io.fotoapparat.parameter.Parameters.Type.PREVIEW_SIZE;
@@ -108,4 +109,12 @@ public class ParametersProvider implements ParametersOperator {
         return selectedParameters.getValue(SENSOR_SENSITIVITY);
     }
 
+    /**
+     * Returns the jpeg quality
+     *
+     * @return  The jpeg quality (1-100)
+     */
+    public Integer getJpegQuality() {
+        return selectedParameters.getValue(JPEG_QUALITY);
+    }
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/v2/parameters/Request.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/v2/parameters/Request.java
@@ -36,6 +36,7 @@ class Request {
     private final FocusMode focus;
     private final Range<Integer> previewFpsRange;
     private final Integer sensorSensitivity;
+    private final Integer jpegQuality;
     private CaptureRequest.Builder captureRequest;
 
     private Request(CameraDevice cameraDevice,
@@ -47,7 +48,8 @@ class Request {
                     Flash flash, boolean shouldSetExposureMode,
                     FocusMode focus,
                     Range<Integer> previewFpsRange,
-                    Integer sensorSensitivity) {
+                    Integer sensorSensitivity,
+                    Integer jpegQuality) {
         this.cameraDevice = cameraDevice;
         this.requestTemplate = requestTemplate;
         this.surfaces = surfaces;
@@ -59,6 +61,7 @@ class Request {
         this.focus = focus;
         this.previewFpsRange = previewFpsRange;
         this.sensorSensitivity = sensorSensitivity;
+        this.jpegQuality = jpegQuality;
     }
 
     static CaptureRequest create(CaptureRequestBuilder builder) throws CameraAccessException {
@@ -73,7 +76,8 @@ class Request {
                 builder.shouldSetExposureMode,
                 builder.focus,
                 builder.previewFpsRange,
-                builder.sensorSensitivity
+                builder.sensorSensitivity,
+                builder.jpegQuality
         )
                 .build();
     }
@@ -100,6 +104,7 @@ class Request {
         setFocus();
         setPreviewFpsRange();
         setSensorSensitivity();
+        setJpegQuality();
 
         return captureRequest.build();
     }
@@ -202,6 +207,13 @@ class Request {
             return;
         }
         captureRequest.set(CaptureRequest.SENSOR_SENSITIVITY, sensorSensitivity);
+    }
+
+    private void setJpegQuality() {
+        if (jpegQuality == null){
+            return;
+        }
+        captureRequest.set(CaptureRequest.JPEG_QUALITY, jpegQuality.byteValue());
     }
 
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/Parameters.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/Parameters.java
@@ -145,7 +145,12 @@ public class Parameters {
         /**
          * Sensor sensitivity (ISO). Expected type: {@link Integer}.
          */
-        SENSOR_SENSITIVITY(Integer.class);
+        SENSOR_SENSITIVITY(Integer.class),
+
+        /**
+         * JPEG QUALITY. Expected type: {@link Integer}. from 1 to 100
+         */
+        JPEG_QUALITY(Integer.class);
 
         private final Class<?> clazz;
 

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/factory/ParametersFactory.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/factory/ParametersFactory.java
@@ -82,6 +82,10 @@ public class ParametersFactory {
         );
     }
 
+
+    /**
+     * @return new parameters by selecting sensor sensitivity from given capabilities.
+     */
     public static Parameters selectSensorSensitivity(@NonNull Capabilities capabilities,
                                                      @NonNull SelectorFunction<Range<Integer>, Integer> selector) {
         return new Parameters().putValue(
@@ -91,5 +95,17 @@ public class ParametersFactory {
                 )
         );
     }
+
+    /**
+     * @param jpegQuality integer (1-100)
+     * @return new parameters with a set jpegQuality
+     */
+    public static Parameters selectJpegQuality(@NonNull Integer jpegQuality) {
+        return new Parameters().putValue(
+                Parameters.Type.JPEG_QUALITY,
+                jpegQuality
+        );
+    }
+
 
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/provider/InitialParametersProvider.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/provider/InitialParametersProvider.java
@@ -32,6 +32,7 @@ public class InitialParametersProvider {
     private final SelectorFunction<Collection<Flash>, Flash> flashSelector;
     private final SelectorFunction<Collection<Range<Integer>>, Range<Integer>> previewFpsRangeSelector;
     private final SelectorFunction<Range<Integer>, Integer> sensorSensitivitySelector;
+    private final Integer jpegQuality;
 
     public InitialParametersProvider(CapabilitiesOperator capabilitiesOperator,
                                      SelectorFunction<Collection<Size>, Size> photoSizeSelector,
@@ -40,6 +41,7 @@ public class InitialParametersProvider {
                                      SelectorFunction<Collection<Flash>, Flash> flashSelector,
                                      SelectorFunction<Collection<Range<Integer>>, Range<Integer>> previewFpsRangeSelector,
                                      SelectorFunction<Range<Integer>, Integer> sensorSensitivitySelector,
+                                     Integer jpegQuality,
                                      InitialParametersValidator parametersValidator) {
         this.capabilitiesOperator = capabilitiesOperator;
         this.photoSizeSelector = photoSizeSelector;
@@ -48,6 +50,7 @@ public class InitialParametersProvider {
         this.flashSelector = flashSelector;
         this.previewFpsRangeSelector = previewFpsRangeSelector;
         this.sensorSensitivitySelector = sensorSensitivitySelector;
+        this.jpegQuality = jpegQuality;
         this.parametersValidator = parametersValidator;
     }
 
@@ -83,7 +86,8 @@ public class InitialParametersProvider {
                 focusModeParameters(capabilities),
                 flashModeParameters(capabilities),
                 previewFpsRange(capabilities),
-                sensorSensitivity(capabilities)
+                sensorSensitivity(capabilities),
+                jpegQuality()
         ));
 
         parametersValidator.validate(parameters);
@@ -146,6 +150,12 @@ public class InitialParametersProvider {
         return ParametersFactory.selectSensorSensitivity(
                 capabilities,
                 sensorSensitivitySelector
+        );
+    }
+
+    private Parameters jpegQuality() {
+        return ParametersFactory.selectJpegQuality(
+                jpegQuality
         );
     }
 

--- a/fotoapparat/src/test/java/io/fotoapparat/parameter/provider/InitialParametersProviderTest.java
+++ b/fotoapparat/src/test/java/io/fotoapparat/parameter/provider/InitialParametersProviderTest.java
@@ -36,6 +36,7 @@ public class InitialParametersProviderTest {
     static final Range<Integer> PREVIEW_FPS_RANGE = Ranges.continuousRange(30000, 30000);
     static final Integer SENSOR_SENSITIVITY = 1000;
     static final Range<Integer> SENSOR_SENSITIVITY_RANGE = Ranges.continuousRange(SENSOR_SENSITIVITY);
+    static final Integer JPEG_QUALITY = 95;
 
     static final Set<Size> ALL_PREVIEW_SIZES = asSet(
             PREVIEW_SIZE,
@@ -107,6 +108,7 @@ public class InitialParametersProviderTest {
                 torch(),
                 PreviewFpsRangeSelectors.rangeWithHighestFps(),
                 SensorSensitivitySelectors.highestSensorSensitivity(),
+                95,
                 initialParametersValidator
         );
 
@@ -139,6 +141,10 @@ public class InitialParametersProviderTest {
                         .putValue(
                                 Parameters.Type.SENSOR_SENSITIVITY,
                                 SENSOR_SENSITIVITY
+                        )
+                        .putValue(
+                                Parameters.Type.JPEG_QUALITY,
+                                JPEG_QUALITY
                         ),
                 parameters
         );

--- a/sample/src/main/java/io/fotoapparat/sample/MainActivity.java
+++ b/sample/src/main/java/io/fotoapparat/sample/MainActivity.java
@@ -21,7 +21,6 @@ import io.fotoapparat.parameter.LensPosition;
 import io.fotoapparat.parameter.ScaleType;
 import io.fotoapparat.parameter.update.UpdateRequest;
 import io.fotoapparat.photo.BitmapPhoto;
-import io.fotoapparat.photo.Photo;
 import io.fotoapparat.preview.Frame;
 import io.fotoapparat.preview.FrameProcessor;
 import io.fotoapparat.result.PendingResult;
@@ -191,8 +190,6 @@ public class MainActivity extends AppCompatActivity {
                         torch(),
                         off()
                 ))
-
-                .jpegQuality(95)
                 .previewFpsRange(rangeWithHighestFps())
                 .sensorSensitivity(highestSensorSensitivity())
                 .frameProcessor(new SampleFrameProcessor())
@@ -210,20 +207,12 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void takePicture() {
-        final PhotoResult photoResult = fotoapparatSwitcher.getCurrentFotoapparat().takePicture();
+        PhotoResult photoResult = fotoapparatSwitcher.getCurrentFotoapparat().takePicture();
 
         photoResult.saveToFile(new File(
                 getExternalFilesDir("photos"),
                 "photo.jpg"
         ));
-
-        photoResult
-                .toPendingResult().whenAvailable(new PendingResult.Callback<Photo>() {
-            @Override
-            public void onResult(Photo result) {
-                Toast.makeText(MainActivity.this, "size of jpeg: "+humanReadableByteCount(result.encodedImage.length, false), Toast.LENGTH_LONG).show();
-            }
-        });
 
         photoResult
                 .toBitmap(scaled(0.25f))
@@ -280,15 +269,6 @@ public class MainActivity extends AppCompatActivity {
             // Perform frame processing, if needed
         }
 
-    }
-
-    //https://stackoverflow.com/questions/3758606/how-to-convert-byte-size-into-human-readable-format-in-java
-    public static String humanReadableByteCount(int bytes, boolean si) {
-        int unit = si ? 1000 : 1024;
-        if (bytes < unit) return bytes + " B";
-        int exp = (int) (Math.log(bytes) / Math.log(unit));
-        String pre = (si ? "kMGTPE" : "KMGTPE").charAt(exp-1) + (si ? "" : "i");
-        return String.format("%.1f %sB", bytes / Math.pow(unit, exp), pre);
     }
 
 }


### PR DESCRIPTION
I added a jpegQuality parameter. 

I copied what was done with sensorSensitivity (except the selector, not needed here as jpegQuality is an int ranging from 0 to 100 for camera Api). I think I've set the default compression value to 95, I'm not sure I have understood everything about what I did as I was in a hurry. I tried to follow existing format conventions as I was doing it.

I integrated it to the sample and I have tested it with Camera1 (not tested with Camera2 yet)


