### PR TITLE
Make  Size and Range serializable to pass device capabilities in Bundle

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/v2/parameters/converters/RangeConverter.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/v2/parameters/converters/RangeConverter.java
@@ -5,6 +5,8 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.RequiresApi;
 
+import java.io.Serializable;
+
 import io.fotoapparat.parameter.range.Range;
 import io.fotoapparat.parameter.range.Ranges;
 
@@ -39,7 +41,7 @@ public class RangeConverter {
      * @return The native Android {@link android.util.Range} value.
      */
     @Nullable
-    public static <T extends Comparable<T>> android.util.Range<T> toNativeRange(@NonNull Range<T> fotoapparatRange) {
+    public static <T extends Comparable<T> & Serializable> android.util.Range<T> toNativeRange(@NonNull Range<T> fotoapparatRange) {
         if (Ranges.isEmpty(fotoapparatRange)) {
             return null;
         } else {

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/Size.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/Size.java
@@ -1,9 +1,13 @@
 package io.fotoapparat.parameter;
 
+import java.io.Serializable;
+
 /**
  * Size in arbitrary units. Immutable.
  */
-public class Size {
+public class Size implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     public final int width;
     public final int height;

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/range/ContinuousRange.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/range/ContinuousRange.java
@@ -2,12 +2,17 @@ package io.fotoapparat.parameter.range;
 
 import android.support.annotation.NonNull;
 
+import java.io.Serializable;
+
 /**
  * Implementation of {@link Range} that represents numeric interval.
  *
  * @param <T> type of numbers in that interval.
  */
-class ContinuousRange<T extends Comparable<T>> implements Range<T> {
+class ContinuousRange<T extends Comparable<T> & Serializable> implements Range<T> {
+
+    private static final long serialVersionUID = 1L;
+
     @NonNull private final T lowerBound;
     @NonNull private final T upperBound;
 

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/range/DiscreteRange.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/range/DiscreteRange.java
@@ -3,6 +3,7 @@ package io.fotoapparat.parameter.range;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -15,11 +16,15 @@ import io.fotoapparat.util.StringUtils;
  *
  * @param <T> type of objects in that set.
  */
-class DiscreteRange<T extends Comparable<? super T>> implements Range<T> {
+class DiscreteRange<T extends Comparable<? super T> & Serializable> implements Range<T> {
+
+    private static final long serialVersionUID = 1L;
+
     @NonNull private final List<T> values;
 
     public DiscreteRange(@NonNull Collection<T> values) {
-        List<T> valuesList = (values instanceof List)
+        boolean isSerializableList = (values instanceof List && values instanceof Serializable);
+        List<T> valuesList = isSerializableList
                 ? (List<T>) values
                 : new ArrayList<>(values);
         Collections.sort(valuesList);

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/range/EmptyRange.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/range/EmptyRange.java
@@ -2,10 +2,14 @@ package io.fotoapparat.parameter.range;
 
 import android.support.annotation.Nullable;
 
+import java.io.Serializable;
+
 /**
  * {@link Range} with no values in it.
  */
-final class EmptyRange<T> implements Range<T> {
+final class EmptyRange<T extends Serializable> implements Range<T> {
+
+    private static final long serialVersionUID = 1L;
 
     @Override
     public boolean contains(T value) {

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/range/Range.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/range/Range.java
@@ -1,11 +1,13 @@
 package io.fotoapparat.parameter.range;
 
+import java.io.Serializable;
+
 /**
  * Interface for representing ranges of arbitrary object.
  *
  * @param <T> type of elements in that range.
  */
-public interface Range<T> {
+public interface Range<T extends Serializable> extends Serializable {
 
     /**
      * Returns highest value in this range.

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/range/Ranges.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/range/Ranges.java
@@ -2,6 +2,7 @@ package io.fotoapparat.parameter.range;
 
 import android.support.annotation.NonNull;
 
+import java.io.Serializable;
 import java.util.Collection;
 
 /**
@@ -12,8 +13,8 @@ public class Ranges {
     /**
      * @return instance of {@link ContinuousRange} with set lower and upper bounds.
      */
-    public static <T extends Comparable<T>> Range<T> continuousRange(@NonNull T lowerBound,
-                                                                     @NonNull T upperBound) {
+    public static <T extends Comparable<T> & Serializable> Range<T> continuousRange(@NonNull T lowerBound,
+                                                                                    @NonNull T upperBound) {
         return new ContinuousRange<>(lowerBound, upperBound);
     }
 
@@ -21,28 +22,28 @@ public class Ranges {
      * @return instance of {@link ContinuousRange} with same lower and upper bounds,
      *         that equal given value.
      */
-    public static <T extends Comparable<T>> Range<T> continuousRange(@NonNull T value) {
+    public static <T extends Comparable<T> & Serializable> Range<T> continuousRange(@NonNull T value) {
         return new ContinuousRange<>(value, value);
     }
 
     /**
      * @return instance of {@link DiscreteRange} with given values from collection.
      */
-    public static <T extends Comparable<T>> Range<T> discreteRange(@NonNull Collection<T> collection) {
+    public static <T extends Comparable<T> & Serializable> Range<T> discreteRange(@NonNull Collection<T> collection) {
         return new DiscreteRange<>(collection);
     }
 
     /**
      * @return instance of {@link EmptyRange}.
      */
-    public static <T extends Comparable<T>> Range<T> emptyRange() {
+    public static <T extends Comparable<T> & Serializable> Range<T> emptyRange() {
         return new EmptyRange<>();
     }
 
     /**
      * Returns <tt>true</tt>, if given range is empty. Otherwise, <tt>false</tt>.
      */
-    public static <T extends Comparable<T>> boolean isEmpty(@NonNull Range<T> range) {
+    public static <T extends Comparable<T> & Serializable> boolean isEmpty(@NonNull Range<T> range) {
         return range instanceof EmptyRange;
     }
 }


### PR DESCRIPTION
Passing device capabilities in Bundle extras requires manual
transformations, as types do not support neither Serializable nor
Parcelable.

Implementing Parcelable is overkill, as those PODs are not
used in any performance-critical code.

Make all Capabilities members serializable, so they can be
passed into DialogFragment inside extras.