### PR TITLE
Catch IllegalStateException and throw CameraException

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/v2/session/SessionManager.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/v2/session/SessionManager.java
@@ -23,8 +23,12 @@ public class SessionManager implements PreviewOperator, CameraConnection.Listene
 
     @Override
     public void startPreview() {
-        session = sessionProvider.getPreviewSession();
-        session.startPreview();
+        try {
+            session = sessionProvider.getPreviewSession();
+            session.startPreview();
+        } catch (IllegalStateException e) {
+            throw new CameraException(e.getMessage());
+        }
     }
 
     @Override

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/v2/session/SessionManager.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/v2/session/SessionManager.java
@@ -2,6 +2,7 @@ package io.fotoapparat.hardware.v2.session;
 
 import android.hardware.camera2.CameraCaptureSession;
 
+import io.fotoapparat.hardware.CameraException;
 import io.fotoapparat.hardware.operators.PreviewOperator;
 import io.fotoapparat.hardware.v2.connection.CameraConnection;
 


### PR DESCRIPTION
Should resolve the issue as seen below. Starting the preview can throw an IllegalStateException with no way to catch it. This catches the ISE and replaces it with the CameraException allowing you to catch the failure and process it rather than forcing a crash.

> Fatal Exception: java.lang.IllegalStateException: Target display surface has not been set.
>        at io.fotoapparat.hardware.v2.session.SessionProvider.getPreviewSession(SessionProvider.java:67)
>        at io.fotoapparat.hardware.v2.session.SessionManager.startPreview(SessionManager.java:26)
>        at io.fotoapparat.hardware.v2.Camera2.startPreview(Camera2.java:103)
>        at io.fotoapparat.routine.StartCameraRoutine.tryToStartCamera(StartCameraRoutine.java:67)
>        at io.fotoapparat.routine.StartCameraRoutine.run(StartCameraRoutine.java:47)
>        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
>        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
>        at java.lang.Thread.run(Thread.java:764)