### PR TITLE
Add Size getter for pixels and megapixels

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/Size.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/Size.java
@@ -29,6 +29,14 @@ public class Size implements Serializable {
         return (float) width / height;
     }
 
+    public int getPixels() {
+        return width * height;
+    }
+
+    public int getMegapixels() {
+        return getPixels()/1000000;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/Size.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/Size.java
@@ -29,12 +29,8 @@ public class Size implements Serializable {
         return (float) width / height;
     }
 
-    public int getPixels() {
+    public int getArea() {
         return width * height;
-    }
-
-    public int getMegapixels() {
-        return getPixels()/1000000;
     }
 
     @Override

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/Size.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/Size.java
@@ -29,6 +29,11 @@ public class Size implements Serializable {
         return (float) width / height;
     }
 
+    /**
+     * Returns the total area of this size.
+     *
+     * @return The area in arbitrary units.
+     */
     public int getArea() {
         return width * height;
     }


### PR DESCRIPTION
Number of pixels is used in some UI logic to sort available sizes. It's tedious to multiply it on each occasion.
Megapixels count is useful for presentation, the same as aspect ratio.