### PR TITLE
Selectors cannot be trusted, therefore we ensure their values are correct

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/FotoapparatBuilder.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/FotoapparatBuilder.java
@@ -4,9 +4,9 @@ import android.content.Context;
 import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
 
-import io.fotoapparat.error.CameraErrorCallback;
 import java.util.Collection;
 
+import io.fotoapparat.error.CameraErrorCallback;
 import io.fotoapparat.hardware.CameraDevice;
 import io.fotoapparat.hardware.provider.CameraProvider;
 import io.fotoapparat.log.Logger;
@@ -59,7 +59,7 @@ public class FotoapparatBuilder {
     SelectorFunction<Collection<Range<Integer>>, Range<Integer>> previewFpsRangeSelector = Selectors.nothing();
     SelectorFunction<Range<Integer>, Integer> sensorSensitivitySelector = Selectors.nothing();
 
-    Integer jpegQuality;
+    int jpegQuality;
 
     ScaleType scaleType = ScaleType.CENTER_CROP;
 
@@ -148,7 +148,7 @@ public class FotoapparatBuilder {
     /**
      * @param jpegQuality of the picture (1-100)
      */
-    public FotoapparatBuilder jpegQuality(@IntRange(from=0,to=100) @NonNull Integer jpegQuality) {
+    public FotoapparatBuilder jpegQuality(@IntRange(from = 0, to = 100) int jpegQuality) {
         this.jpegQuality = jpegQuality;
         return this;
     }

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/factory/ParametersFactory.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/factory/ParametersFactory.java
@@ -107,7 +107,7 @@ public class ParametersFactory {
      * @param jpegQuality integer (1-100)
      * @return new parameters with a set jpegQuality
      */
-    public static Parameters selectJpegQuality(@NonNull Integer jpegQuality) {
+    public static Parameters selectJpegQuality(int jpegQuality) {
         return new Parameters().putValue(
                 Parameters.Type.JPEG_QUALITY,
                 ensureJpegQualityRange(jpegQuality)

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/factory/ParametersFactory.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/factory/ParametersFactory.java
@@ -2,7 +2,9 @@ package io.fotoapparat.parameter.factory;
 
 import android.support.annotation.NonNull;
 
+import java.io.Serializable;
 import java.util.Collection;
+import java.util.Set;
 
 import io.fotoapparat.hardware.Capabilities;
 import io.fotoapparat.parameter.Flash;
@@ -24,7 +26,8 @@ public class ParametersFactory {
                                                @NonNull SelectorFunction<Collection<Size>, Size> selector) {
         return new Parameters().putValue(
                 Parameters.Type.PICTURE_SIZE,
-                selector.select(
+                selectSafely(
+                        selector,
                         capabilities.supportedPictureSizes()
                 )
         );
@@ -37,7 +40,8 @@ public class ParametersFactory {
                                                @NonNull SelectorFunction<Collection<Size>, Size> selector) {
         return new Parameters().putValue(
                 Parameters.Type.PREVIEW_SIZE,
-                selector.select(
+                selectSafely(
+                        selector,
                         capabilities.supportedPreviewSizes()
                 )
         );
@@ -50,7 +54,8 @@ public class ParametersFactory {
                                              @NonNull SelectorFunction<Collection<FocusMode>, FocusMode> selector) {
         return new Parameters().putValue(
                 Parameters.Type.FOCUS_MODE,
-                selector.select(
+                selectSafely(
+                        selector,
                         capabilities.supportedFocusModes()
                 )
         );
@@ -63,7 +68,8 @@ public class ParametersFactory {
                                              @NonNull SelectorFunction<Collection<Flash>, Flash> selector) {
         return new Parameters().putValue(
                 Parameters.Type.FLASH,
-                selector.select(
+                selectSafely(
+                        selector,
                         capabilities.supportedFlashModes()
                 )
         );
@@ -76,12 +82,12 @@ public class ParametersFactory {
                                                    @NonNull SelectorFunction<Collection<Range<Integer>>, Range<Integer>> selector) {
         return new Parameters().putValue(
                 Parameters.Type.PREVIEW_FPS_RANGE,
-                selector.select(
+                selectSafely(
+                        selector,
                         capabilities.supportedPreviewFpsRanges()
                 )
         );
     }
-
 
     /**
      * @return new parameters by selecting sensor sensitivity from given capabilities.
@@ -90,7 +96,8 @@ public class ParametersFactory {
                                                      @NonNull SelectorFunction<Range<Integer>, Integer> selector) {
         return new Parameters().putValue(
                 Parameters.Type.SENSOR_SENSITIVITY,
-                selector.select(
+                selectSafely(
+                        selector,
                         capabilities.supportedSensorSensitivityRange()
                 )
         );
@@ -103,9 +110,42 @@ public class ParametersFactory {
     public static Parameters selectJpegQuality(@NonNull Integer jpegQuality) {
         return new Parameters().putValue(
                 Parameters.Type.JPEG_QUALITY,
-                jpegQuality
+                ensureIntegerRange(jpegQuality)
         );
     }
 
+    private static Integer ensureIntegerRange(Integer jpegQuality) {
+        if (jpegQuality == null) {
+            throw new IllegalArgumentException("Jpeg quality was null");
+        }
+        if (jpegQuality < 1 || 100 < jpegQuality) {
+            throw new IllegalArgumentException("Jpeg quality was not in 0-100 range.");
+        }
+        return jpegQuality;
+    }
+
+    private static <T extends Serializable> T selectSafely(
+            SelectorFunction<Range<T>, T> selector,
+            Range<T> capabilities
+    ) {
+        T selectedParameter = selector.select(capabilities);
+        if (!capabilities.contains(selectedParameter)) {
+            throw new IllegalArgumentException(
+                    "The selected parameter is not in the supported set of values.");
+        }
+        return selectedParameter;
+    }
+
+    private static <T> T selectSafely(
+            SelectorFunction<Collection<T>, T> selector,
+            Set<T> capabilities
+    ) {
+        T selectedParameter = selector.select(capabilities);
+        if (!capabilities.contains(selectedParameter)) {
+            throw new IllegalArgumentException(
+                    "The selected parameter is not in the supported set of values.");
+        }
+        return selectedParameter;
+    }
 
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/factory/ParametersFactory.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/factory/ParametersFactory.java
@@ -114,10 +114,7 @@ public class ParametersFactory {
         );
     }
 
-    private static Integer ensureJpegQualityRange(Integer jpegQuality) {
-        if (jpegQuality == null) {
-            throw new IllegalArgumentException("Jpeg quality was null");
-        }
+    private static Integer ensureJpegQualityRange(int jpegQuality) {
         if (jpegQuality < 1 || 100 < jpegQuality) {
             throw new IllegalArgumentException("Jpeg quality was not in 0-100 range.");
         }

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/factory/ParametersFactory.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/factory/ParametersFactory.java
@@ -110,11 +110,11 @@ public class ParametersFactory {
     public static Parameters selectJpegQuality(@NonNull Integer jpegQuality) {
         return new Parameters().putValue(
                 Parameters.Type.JPEG_QUALITY,
-                ensureIntegerRange(jpegQuality)
+                ensureJpegQualityRange(jpegQuality)
         );
     }
 
-    private static Integer ensureIntegerRange(Integer jpegQuality) {
+    private static Integer ensureJpegQualityRange(Integer jpegQuality) {
         if (jpegQuality == null) {
             throw new IllegalArgumentException("Jpeg quality was null");
         }

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/provider/InitialParametersProvider.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/provider/InitialParametersProvider.java
@@ -31,7 +31,7 @@ public class InitialParametersProvider {
     private final SelectorFunction<Collection<Flash>, Flash> flashSelector;
     private final SelectorFunction<Collection<Range<Integer>>, Range<Integer>> previewFpsRangeSelector;
     private final SelectorFunction<Range<Integer>, Integer> sensorSensitivitySelector;
-    private final Integer jpegQuality;
+    private final int jpegQuality;
 
     public InitialParametersProvider(CapabilitiesOperator capabilitiesOperator,
                                      SelectorFunction<Collection<Size>, Size> photoSizeSelector,
@@ -40,7 +40,7 @@ public class InitialParametersProvider {
                                      SelectorFunction<Collection<Flash>, Flash> flashSelector,
                                      SelectorFunction<Collection<Range<Integer>>, Range<Integer>> previewFpsRangeSelector,
                                      SelectorFunction<Range<Integer>, Integer> sensorSensitivitySelector,
-                                     Integer jpegQuality,
+                                     int jpegQuality,
                                      InitialParametersValidator parametersValidator) {
         this.capabilitiesOperator = capabilitiesOperator;
         this.photoSizeSelector = photoSizeSelector;

--- a/fotoapparat/src/test/java/io/fotoapparat/parameter/factory/ParametersFactoryTest.java
+++ b/fotoapparat/src/test/java/io/fotoapparat/parameter/factory/ParametersFactoryTest.java
@@ -2,6 +2,8 @@ package io.fotoapparat.parameter.factory;
 
 import org.junit.Test;
 
+import java.util.Collections;
+
 import io.fotoapparat.hardware.Capabilities;
 import io.fotoapparat.parameter.Flash;
 import io.fotoapparat.parameter.FocusMode;
@@ -16,15 +18,25 @@ import static junit.framework.Assert.assertEquals;
 
 public class ParametersFactoryTest {
 
-    static final Capabilities CAPABILITIES = Capabilities.empty();
+    static final Capabilities EMPTY_CAPABILITIES = Capabilities.empty();
 
     @Test
     public void selectPictureSize() throws Exception {
         // Given
         Size size = new Size(100, 100);
 
+        Capabilities capabilities = new Capabilities(
+                Collections.singleton(size),
+                Collections.<Size>emptySet(),
+                Collections.<FocusMode>emptySet(),
+                Collections.<Flash>emptySet(),
+                Collections.<Range<Integer>>emptySet(),
+                Ranges.<Integer>emptyRange(),
+                false
+        );
+
         // When
-        Parameters result = ParametersFactory.selectPictureSize(CAPABILITIES,
+        Parameters result = ParametersFactory.selectPictureSize(capabilities,
                 selectFromCollection(size));
 
         // Then
@@ -39,8 +51,18 @@ public class ParametersFactoryTest {
         // Given
         Size size = new Size(100, 100);
 
+        Capabilities capabilities = new Capabilities(
+                Collections.<Size>emptySet(),
+                Collections.singleton(size),
+                Collections.<FocusMode>emptySet(),
+                Collections.<Flash>emptySet(),
+                Collections.<Range<Integer>>emptySet(),
+                Ranges.<Integer>emptyRange(),
+                false
+        );
+
         // When
-        Parameters result = ParametersFactory.selectPreviewSize(CAPABILITIES,
+        Parameters result = ParametersFactory.selectPreviewSize(capabilities,
                 selectFromCollection(size));
 
         // Then
@@ -55,8 +77,18 @@ public class ParametersFactoryTest {
         // Given
         FocusMode focusMode = FocusMode.AUTO;
 
+        Capabilities capabilities = new Capabilities(
+                Collections.<Size>emptySet(),
+                Collections.<Size>emptySet(),
+                Collections.singleton(focusMode),
+                Collections.<Flash>emptySet(),
+                Collections.<Range<Integer>>emptySet(),
+                Ranges.<Integer>emptyRange(),
+                false
+        );
+
         // When
-        Parameters result = ParametersFactory.selectFocusMode(CAPABILITIES,
+        Parameters result = ParametersFactory.selectFocusMode(capabilities,
                 selectFromCollection(focusMode));
 
         // Then
@@ -71,8 +103,18 @@ public class ParametersFactoryTest {
         // Given
         Flash flash = Flash.AUTO;
 
+        Capabilities capabilities = new Capabilities(
+                Collections.<Size>emptySet(),
+                Collections.<Size>emptySet(),
+                Collections.<FocusMode>emptySet(),
+                Collections.singleton(flash),
+                Collections.<Range<Integer>>emptySet(),
+                Ranges.<Integer>emptyRange(),
+                false
+        );
+
         // When
-        Parameters result = ParametersFactory.selectFlashMode(CAPABILITIES,
+        Parameters result = ParametersFactory.selectFlashMode(capabilities,
                 selectFromCollection(flash));
 
         // Then
@@ -87,8 +129,18 @@ public class ParametersFactoryTest {
         // Given
         Range<Integer> range = Ranges.continuousRange(30000, 30000);
 
+        Capabilities capabilities = new Capabilities(
+                Collections.<Size>emptySet(),
+                Collections.<Size>emptySet(),
+                Collections.<FocusMode>emptySet(),
+                Collections.<Flash>emptySet(),
+                Collections.singleton(range),
+                Ranges.<Integer>emptyRange(),
+                false
+        );
+
         // When
-        Parameters result = ParametersFactory.selectPreviewFpsRange(CAPABILITIES,
+        Parameters result = ParametersFactory.selectPreviewFpsRange(capabilities,
                 selectFromCollection(range));
 
         // Then
@@ -103,8 +155,18 @@ public class ParametersFactoryTest {
         // When
         Integer isoValue = 1200;
 
+        Capabilities capabilities = new Capabilities(
+                Collections.<Size>emptySet(),
+                Collections.<Size>emptySet(),
+                Collections.<FocusMode>emptySet(),
+                Collections.<Flash>emptySet(),
+                Collections.<Range<Integer>>emptySet(),
+                Ranges.continuousRange(isoValue),
+                false
+        );
+
         // Then
-        Parameters result = ParametersFactory.selectSensorSensitivity(CAPABILITIES,
+        Parameters result = ParametersFactory.selectSensorSensitivity(capabilities,
                 TestSelectors.<Range<Integer>, Integer>select(isoValue));
 
         assertEquals(
@@ -113,4 +175,66 @@ public class ParametersFactoryTest {
         );
     }
 
+    @Test
+    public void selectJpegQuality() throws Exception {
+        // Given
+        int quality = 100;
+
+        // When
+        Parameters result = ParametersFactory.selectJpegQuality(quality);
+
+        // Then
+        assertEquals(
+                new Parameters().putValue(Parameters.Type.JPEG_QUALITY, quality),
+                result
+        );
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidCollectionSelector() throws Exception {
+        // Given
+        Size size = new Size(100, 100);
+
+        // When
+        ParametersFactory.selectPictureSize(EMPTY_CAPABILITIES, selectFromCollection(size));
+
+        // Then
+        // Exception
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidRangeSelector() throws Exception {
+        // Given
+        Range<Integer> range = Ranges.continuousRange(30000, 30000);
+
+        // When
+        ParametersFactory.selectPreviewFpsRange(EMPTY_CAPABILITIES, selectFromCollection(range));
+
+        // Then
+        // Exception
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidSmallerJpegQuality() throws Exception {
+        // Given
+        int quality = -1;
+
+        // When
+        ParametersFactory.selectJpegQuality(quality);
+
+        // Then
+        // Exception
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidBiggerJpegQuality() throws Exception {
+        // Given
+        int quality = 101;
+
+        // When
+        ParametersFactory.selectJpegQuality(quality);
+
+        // Then
+        // Exception
+    }
 }

--- a/fotoapparat/src/test/java/io/fotoapparat/parameter/factory/ParametersFactoryTest.java
+++ b/fotoapparat/src/test/java/io/fotoapparat/parameter/factory/ParametersFactoryTest.java
@@ -205,10 +205,11 @@ public class ParametersFactoryTest {
     @Test(expected = IllegalArgumentException.class)
     public void invalidRangeSelector() throws Exception {
         // Given
-        Range<Integer> range = Ranges.continuousRange(30000, 30000);
+        Integer isoValue = 1200;
 
         // When
-        ParametersFactory.selectPreviewFpsRange(EMPTY_CAPABILITIES, selectFromCollection(range));
+        ParametersFactory.selectSensorSensitivity(EMPTY_CAPABILITIES,
+                TestSelectors.<Range<Integer>, Integer>select(isoValue));
 
         // Then
         // Exception

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Mar 23 22:04:38 CET 2017
+#Mon Dec 04 00:49:03 CET 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-4.4-20171031235950+0000-all.zip


### PR DESCRIPTION
Prevents issues like #142 