### PR TITLE
Update selectors validation

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/Fotoapparat.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/Fotoapparat.java
@@ -109,6 +109,7 @@ public class Fotoapparat {
                 builder.previewFpsRangeSelector,
                 builder.sensorSensitivitySelector,
                 builder.jpegQuality,
+                builder.logger,
                 parametersValidator
         );
 

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/v1/CameraParametersDecorator.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/v1/CameraParametersDecorator.java
@@ -166,17 +166,16 @@ public class CameraParametersDecorator {
     /**
      * @see Camera.Parameters#getJpegQuality()
      */
-    public int getJpegQuality(){
+    public int getJpegQuality() {
         return cameraParameters.getJpegQuality();
     }
 
     /**
      * @see Camera.Parameters#setJpegQuality(int)
      */
-    public void setJpegQuality(int quality){
+    public void setJpegQuality(int quality) {
         cameraParameters.setJpegQuality(quality);
     }
-
 
     @Nullable
     private String findExistingKey(@NonNull String[] keys) {

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/factory/ParametersFactory.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/factory/ParametersFactory.java
@@ -115,7 +115,7 @@ public class ParametersFactory {
     }
 
     private static Integer ensureJpegQualityRange(int jpegQuality) {
-        if (jpegQuality < 1 || 100 < jpegQuality) {
+        if (jpegQuality < 0 || 100 < jpegQuality) {
             throw new IllegalArgumentException("Jpeg quality was not in 0-100 range.");
         }
         return jpegQuality;

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/provider/InitialParametersProvider.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/provider/InitialParametersProvider.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import io.fotoapparat.hardware.CameraDevice;
 import io.fotoapparat.hardware.Capabilities;
 import io.fotoapparat.hardware.operators.CapabilitiesOperator;
+import io.fotoapparat.log.Logger;
 import io.fotoapparat.parameter.Flash;
 import io.fotoapparat.parameter.FocusMode;
 import io.fotoapparat.parameter.Parameters;
@@ -23,6 +24,7 @@ import static java.util.Arrays.asList;
  */
 public class InitialParametersProvider {
 
+    private final Logger logger;
     private final InitialParametersValidator parametersValidator;
     private final CapabilitiesOperator capabilitiesOperator;
     private final SelectorFunction<Collection<Size>, Size> photoSizeSelector;
@@ -41,6 +43,7 @@ public class InitialParametersProvider {
                                      SelectorFunction<Collection<Range<Integer>>, Range<Integer>> previewFpsRangeSelector,
                                      SelectorFunction<Range<Integer>, Integer> sensorSensitivitySelector,
                                      int jpegQuality,
+                                     Logger logger,
                                      InitialParametersValidator parametersValidator) {
         this.capabilitiesOperator = capabilitiesOperator;
         this.photoSizeSelector = photoSizeSelector;
@@ -50,6 +53,7 @@ public class InitialParametersProvider {
         this.previewFpsRangeSelector = previewFpsRangeSelector;
         this.sensorSensitivitySelector = sensorSensitivitySelector;
         this.jpegQuality = jpegQuality;
+        this.logger = logger;
         this.parametersValidator = parametersValidator;
     }
 
@@ -134,14 +138,16 @@ public class InitialParametersProvider {
     private Parameters previewFpsRange(Capabilities capabilities) {
         return ParametersFactory.selectPreviewFpsRange(
                 capabilities,
-                previewFpsRangeSelector
+                previewFpsRangeSelector,
+                logger
         );
     }
 
     private Parameters sensorSensitivity(Capabilities capabilities) {
         return ParametersFactory.selectSensorSensitivity(
                 capabilities,
-                sensorSensitivitySelector
+                sensorSensitivitySelector,
+                logger
         );
     }
 

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/selector/PreviewFpsRangeSelectors.java
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/selector/PreviewFpsRangeSelectors.java
@@ -1,5 +1,6 @@
 package io.fotoapparat.parameter.selector;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -74,4 +75,33 @@ public class PreviewFpsRangeSelectors {
         };
     }
 
+    public static SelectorFunction<Collection<Range<Integer>>, Range<Integer>> customFpsRange() {
+        return new SelectorFunction<Collection<Range<Integer>>, Range<Integer>>() {
+            @Override
+            public Range<Integer> select(Collection<Range<Integer>> items) {
+                if (items.isEmpty()) {
+                    return null;
+                }
+
+                ArrayList<Range<Integer>> rangeArraylist= new ArrayList<>();
+                for (Range<Integer> range : items) {
+
+                    if (range.highest().intValue() != range.lowest().intValue()) {
+
+                        rangeArraylist.add(range);
+                    }
+
+                }
+
+                if (!rangeArraylist.isEmpty()) {
+
+                    return Collections.max(rangeArraylist, COMPARATOR_BY_BOUNDS);
+                } else {
+
+                    return Collections.max(items, COMPARATOR_BY_BOUNDS);
+                }
+
+            }
+        };
+    }
 }

--- a/fotoapparat/src/test/java/io/fotoapparat/parameter/factory/ParametersFactoryTest.java
+++ b/fotoapparat/src/test/java/io/fotoapparat/parameter/factory/ParametersFactoryTest.java
@@ -1,24 +1,35 @@
 package io.fotoapparat.parameter.factory;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Collection;
 import java.util.Collections;
 
 import io.fotoapparat.hardware.Capabilities;
+import io.fotoapparat.log.Logger;
 import io.fotoapparat.parameter.Flash;
 import io.fotoapparat.parameter.FocusMode;
 import io.fotoapparat.parameter.Parameters;
 import io.fotoapparat.parameter.Size;
 import io.fotoapparat.parameter.range.Range;
 import io.fotoapparat.parameter.range.Ranges;
+import io.fotoapparat.parameter.selector.Selectors;
 import io.fotoapparat.util.TestSelectors;
 
 import static io.fotoapparat.util.TestSelectors.selectFromCollection;
 import static junit.framework.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
 
+@RunWith(MockitoJUnitRunner.class)
 public class ParametersFactoryTest {
 
     static final Capabilities EMPTY_CAPABILITIES = Capabilities.empty();
+    @Mock
+    Logger logger;
 
     @Test
     public void selectPictureSize() throws Exception {
@@ -141,7 +152,7 @@ public class ParametersFactoryTest {
 
         // When
         Parameters result = ParametersFactory.selectPreviewFpsRange(capabilities,
-                selectFromCollection(range));
+                selectFromCollection(range), logger);
 
         // Then
         assertEquals(
@@ -167,7 +178,7 @@ public class ParametersFactoryTest {
 
         // Then
         Parameters result = ParametersFactory.selectSensorSensitivity(capabilities,
-                TestSelectors.<Range<Integer>, Integer>select(isoValue));
+                TestSelectors.<Range<Integer>, Integer>select(isoValue), logger);
 
         assertEquals(
                 new Parameters().putValue(Parameters.Type.SENSOR_SENSITIVITY, isoValue),
@@ -190,6 +201,36 @@ public class ParametersFactoryTest {
         );
     }
 
+    @Test
+    public void emptyRangeSelector() throws Exception {
+        // Given
+
+        // When
+        ParametersFactory.selectSensorSensitivity(
+                EMPTY_CAPABILITIES,
+                Selectors.<Range<Integer>, Integer>nothing(),
+                logger
+        );
+
+        // Then
+        verify(logger).log(anyString());
+    }
+
+    @Test
+    public void emptyPreviewFpsRange() throws Exception {
+        // Given
+
+        // When
+        ParametersFactory.selectPreviewFpsRange(
+                EMPTY_CAPABILITIES,
+                Selectors.<Collection<Range<Integer>>, Range<Integer>>nothing(),
+                logger
+        );
+
+        // Then
+        verify(logger).log(anyString());
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void invalidCollectionSelector() throws Exception {
         // Given
@@ -197,19 +238,6 @@ public class ParametersFactoryTest {
 
         // When
         ParametersFactory.selectPictureSize(EMPTY_CAPABILITIES, selectFromCollection(size));
-
-        // Then
-        // Exception
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void invalidRangeSelector() throws Exception {
-        // Given
-        Integer isoValue = 1200;
-
-        // When
-        ParametersFactory.selectSensorSensitivity(EMPTY_CAPABILITIES,
-                TestSelectors.<Range<Integer>, Integer>select(isoValue));
 
         // Then
         // Exception

--- a/fotoapparat/src/test/java/io/fotoapparat/parameter/provider/InitialParametersProviderTest.java
+++ b/fotoapparat/src/test/java/io/fotoapparat/parameter/provider/InitialParametersProviderTest.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import io.fotoapparat.hardware.Capabilities;
 import io.fotoapparat.hardware.operators.CapabilitiesOperator;
+import io.fotoapparat.log.Loggers;
 import io.fotoapparat.parameter.Flash;
 import io.fotoapparat.parameter.FocusMode;
 import io.fotoapparat.parameter.Parameters;
@@ -109,6 +110,7 @@ public class InitialParametersProviderTest {
                 PreviewFpsRangeSelectors.rangeWithHighestFps(),
                 SensorSensitivitySelectors.highestSensorSensitivity(),
                 95,
+                Loggers.none(),
                 initialParametersValidator
         );
 


### PR DESCRIPTION
This is a bugfix by comments by @jpribble in #143 :  Fix range validation & allow null value for fps range & iso. 

Alternatively we could always set one, however reason to allow null over force value:

- FPS range list could be empty, so 🤷‍♂️.  (I have not validated this, I see the selector created by @friendoye)
- ISO should be better to be left untouched by FA by default. Hardware manufactures *could* be smarter than us and select the correct ISO and avoid issue like #139. Or range could simply be null (I see @JPLITPeople's selector which returns null if list is empty in the #139).

If lists are ensured to always contain a value then we could discuss to have a default value and not allow nulls