### PR TITLE
Accept rotation in degrees instead of Photos in ExifOrientationHelper

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/exif/ExifOrientationWriter.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/exif/ExifOrientationWriter.kt
@@ -1,6 +1,5 @@
 package io.fotoapparat.exif
 
-import io.fotoapparat.result.Photo
 import java.io.File
 
 /**
@@ -15,5 +14,5 @@ internal interface ExifOrientationWriter {
      * @param photo    Photo stored in the file.
      * @throws FileSaveException If writing has failed.
      */
-    fun writeExifOrientation(file: File, photo: Photo)
+    fun writeExifOrientation(file: File, rotationDegrees: Int)
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/exif/ExifWriter.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/exif/ExifWriter.kt
@@ -2,7 +2,6 @@ package io.fotoapparat.exif
 
 import android.media.ExifInterface
 import io.fotoapparat.exception.FileSaveException
-import io.fotoapparat.result.Photo
 import java.io.File
 import java.io.IOException
 
@@ -13,12 +12,12 @@ internal object ExifWriter : ExifOrientationWriter {
 
 
     @Throws(FileSaveException::class)
-    override fun writeExifOrientation(file: File, photo: Photo) {
+    override fun writeExifOrientation(file: File, rotationDegrees: Int) {
         try {
             val exifInterface = ExifInterface(file.path)
             exifInterface.setAttribute(
                     ExifInterface.TAG_ORIENTATION,
-                    toExifOrientation(photo.rotationDegrees).toString()
+                    toExifOrientation(rotationDegrees).toString()
             )
             exifInterface.saveAttributes()
         } catch (e: IOException) {

--- a/fotoapparat/src/main/java/io/fotoapparat/result/transformer/SaveToFileTransformer.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/result/transformer/SaveToFileTransformer.kt
@@ -23,7 +23,7 @@ internal class SaveToFileTransformer(
         try {
             saveImage(input, outputStream)
 
-            exifOrientationWriter.writeExifOrientation(file, input)
+            exifOrientationWriter.writeExifOrientation(file, input.rotationDegrees)
         } catch (e: IOException) {
             throw FileSaveException(e)
         }

--- a/fotoapparat/src/test/java/io/fotoapparat/result/transformer/SaveToFileTransformerTest.kt
+++ b/fotoapparat/src/test/java/io/fotoapparat/result/transformer/SaveToFileTransformerTest.kt
@@ -51,7 +51,7 @@ internal class SaveToFileTransformerTest {
 
         verify(exifOrientationWriter).writeExifOrientation(
                 file,
-                photo
+                photo.rotationDegrees
         )
     }
 


### PR DESCRIPTION
`ExifWriter` can be simplified to just use `Ints` as its function parameter instead of `Photos`.