### PR TITLE
Add typealiases. Codestyle improvements.

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/Fotoapparat.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/Fotoapparat.kt
@@ -187,11 +187,9 @@ class Fotoapparat
      *
      * @see Fotoapparat.focus
      */
-    fun autoFocus(): Fotoapparat {
+    fun autoFocus(): Fotoapparat = apply {
         logger.recordMethod()
         focus()
-
-        return this
     }
 
     /**

--- a/fotoapparat/src/main/java/io/fotoapparat/Fotoapparat.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/Fotoapparat.kt
@@ -3,9 +3,9 @@ package io.fotoapparat
 import android.content.Context
 import android.support.annotation.FloatRange
 import io.fotoapparat.capability.Capabilities
-import io.fotoapparat.characteristic.LensPosition
 import io.fotoapparat.configuration.CameraConfiguration
 import io.fotoapparat.configuration.Configuration
+import io.fotoapparat.error.CameraErrorCallback
 import io.fotoapparat.error.onMainThread
 import io.fotoapparat.exception.camera.CameraException
 import io.fotoapparat.hardware.Device
@@ -27,10 +27,7 @@ import io.fotoapparat.routine.focus.focus
 import io.fotoapparat.routine.parameter.getCurrentParameters
 import io.fotoapparat.routine.photo.takePhoto
 import io.fotoapparat.routine.zoom.updateZoomLevel
-import io.fotoapparat.selector.back
-import io.fotoapparat.selector.external
-import io.fotoapparat.selector.firstAvailable
-import io.fotoapparat.selector.front
+import io.fotoapparat.selector.*
 import io.fotoapparat.view.CameraRenderer
 import io.fotoapparat.view.FocalPointSelector
 import java.util.concurrent.FutureTask
@@ -43,14 +40,14 @@ class Fotoapparat
         context: Context,
         view: CameraRenderer,
         focusView: FocalPointSelector? = null,
-        lensPosition: Collection<LensPosition>.() -> LensPosition? = firstAvailable(
+        lensPosition: LensPositionSelector = firstAvailable(
                 back(),
                 front(),
                 external()
         ),
         scaleType: ScaleType = ScaleType.CenterCrop,
         cameraConfiguration: CameraConfiguration = CameraConfiguration.default(),
-        cameraErrorCallback: ((CameraException) -> Unit) = {},
+        cameraErrorCallback: CameraErrorCallback = {},
         private val logger: Logger = none()
 ) {
 
@@ -220,7 +217,7 @@ class Fotoapparat
      * stopped automatically and new will start.
      */
     fun switchTo(
-            lensPosition: Collection<LensPosition>.() -> LensPosition?,
+            lensPosition: LensPositionSelector,
             cameraConfiguration: CameraConfiguration
     ) {
         logger.recordMethod()
@@ -237,14 +234,12 @@ class Fotoapparat
      * @return `true` if selected lens position is available. `false` if it is not available.
      */
     fun isAvailable(
-            selector: (Collection<LensPosition>) -> LensPosition?
-    ): Boolean {
-        return device.canSelectCamera(selector)
-    }
+            selector: LensPositionSelector
+    ): Boolean = device.canSelectCamera(selector)
 
     companion object {
 
         @JvmStatic
-        fun with(context: Context) = FotoapparatBuilder(context)
+        fun with(context: Context): FotoapparatBuilder = FotoapparatBuilder(context)
     }
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/FotoapparatBuilder.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/FotoapparatBuilder.kt
@@ -1,17 +1,13 @@
 package io.fotoapparat
 
 import android.content.Context
-import io.fotoapparat.characteristic.LensPosition
 import io.fotoapparat.configuration.CameraConfiguration
-import io.fotoapparat.exception.camera.CameraException
+import io.fotoapparat.error.CameraErrorCallback
 import io.fotoapparat.log.Logger
 import io.fotoapparat.log.none
-import io.fotoapparat.parameter.*
-import io.fotoapparat.preview.Frame
-import io.fotoapparat.selector.back
-import io.fotoapparat.selector.external
-import io.fotoapparat.selector.firstAvailable
-import io.fotoapparat.selector.front
+import io.fotoapparat.parameter.ScaleType
+import io.fotoapparat.selector.*
+import io.fotoapparat.util.FrameProcessor
 import io.fotoapparat.view.CameraRenderer
 import io.fotoapparat.view.CameraView
 
@@ -20,12 +16,12 @@ import io.fotoapparat.view.CameraView
  */
 class FotoapparatBuilder internal constructor(private var context: Context) {
 
-    internal var lensPositionSelector: Iterable<LensPosition>.() -> LensPosition? = firstAvailable(
+    internal var lensPositionSelector: LensPositionSelector = firstAvailable(
             back(),
             front(),
             external()
     )
-    internal var cameraErrorCallback: (CameraException) -> Unit = {}
+    internal var cameraErrorCallback: CameraErrorCallback = {}
     internal var renderer: CameraRenderer? = null
     internal var scaleType: ScaleType = ScaleType.CenterCrop
     internal var logger: Logger = none()
@@ -35,127 +31,109 @@ class FotoapparatBuilder internal constructor(private var context: Context) {
     /**
      * @param selector camera sensor position from list of available positions.
      */
-    fun lensPosition(selector: Iterable<LensPosition>.() -> LensPosition?): FotoapparatBuilder {
-        lensPositionSelector = selector
-        return this
-    }
+    fun lensPosition(selector: LensPositionSelector): FotoapparatBuilder =
+            apply { lensPositionSelector = selector }
 
     /**
      * @param scaleType of preview inside the view.
      */
-    fun previewScaleType(scaleType: ScaleType): FotoapparatBuilder {
-        this.scaleType = scaleType
-        return this
-    }
+    fun previewScaleType(scaleType: ScaleType): FotoapparatBuilder =
+            apply { this.scaleType = scaleType }
 
     /**
      * @param selector selects resolution of the photo (in pixels) from list of available resolutions.
      */
-    fun photoResolution(selector: Iterable<Resolution>.() -> Resolution?): FotoapparatBuilder {
+    fun photoResolution(selector: ResolutionSelector): FotoapparatBuilder = apply {
         configuration = configuration.copy(
                 pictureResolution = selector
         )
-        return this
     }
 
     /**
      * @param selector selects size of preview stream (in pixels) from list of available resolutions.
      */
-    fun previewResolution(selector: Iterable<Resolution>.() -> Resolution?): FotoapparatBuilder {
+    fun previewResolution(selector: ResolutionSelector): FotoapparatBuilder = apply {
         configuration = configuration.copy(
                 previewResolution = selector
         )
-        return this
     }
 
 
     /**
      * @param selector selects focus mode from list of available modes.
      */
-    fun focusMode(selector: Iterable<FocusMode>.() -> FocusMode?): FotoapparatBuilder {
+    fun focusMode(selector: FocusModeSelector): FotoapparatBuilder = apply {
         configuration = configuration.copy(
                 focusMode = selector
         )
-        return this
     }
 
     /**
      * @param selector selects flash mode from list of available modes.
      */
-    fun flash(selector: Iterable<Flash>.() -> Flash?): FotoapparatBuilder {
+    fun flash(selector: FlashSelector): FotoapparatBuilder = apply {
         configuration = configuration.copy(
                 flashMode = selector
         )
-        return this
     }
 
     /**
      * @param selector selects preview FPS range from list of available ranges.
      */
-    fun previewFpsRange(selector: Iterable<FpsRange>.() -> FpsRange?): FotoapparatBuilder {
+    fun previewFpsRange(selector: FpsRangeSelector): FotoapparatBuilder = apply {
         configuration = configuration.copy(
                 previewFpsRange = selector
         )
-        return this
     }
 
     /**
      * @param selector selects ISO value from range of available values.
      */
-    fun sensorSensitivity(selector: Iterable<Int>.() -> Int?): FotoapparatBuilder {
+    fun sensorSensitivity(selector: SensorSensitivitySelector): FotoapparatBuilder = apply {
         configuration = configuration.copy(
                 sensorSensitivity = selector
         )
-        return this
     }
 
     /**
      * @param selector of the Jpeg picture quality.
      */
-    fun jpegQuality(selector: IntRange.() -> Int?): FotoapparatBuilder {
+    fun jpegQuality(selector: QualitySelector): FotoapparatBuilder = apply {
         configuration = configuration.copy(
                 jpegQuality = selector
         )
-        return this
     }
 
     /**
      * @param frameProcessor receives preview frames for processing.
      * @see FrameProcessor
      */
-    fun frameProcessor(frameProcessor: (Frame) -> Unit): FotoapparatBuilder {
+    fun frameProcessor(frameProcessor: FrameProcessor): FotoapparatBuilder = apply {
         configuration = configuration.copy(
                 frameProcessor = frameProcessor
         )
-        return this
     }
 
     /**
      * @param logger logger which will print logs. No logger is set by default.
      * @see io.fotoapparat.log.Loggers
      */
-    fun logger(logger: Logger): FotoapparatBuilder {
-        this.logger = logger
-        return this
-    }
+    fun logger(logger: Logger): FotoapparatBuilder =
+            apply { this.logger = logger }
 
     /**
      * @param callback which will be notified when camera error happens in Fotoapparat.
      * @see CameraErrorCallback
      */
-    fun cameraErrorCallback(callback: (CameraException) -> Unit): FotoapparatBuilder {
-        cameraErrorCallback = callback
-        return this
-    }
+    fun cameraErrorCallback(callback: CameraErrorCallback): FotoapparatBuilder =
+            apply { cameraErrorCallback = callback }
 
     /**
      * @param renderer view which will draw the stream from the camera.
      * @see CameraView
      */
-    fun into(renderer: CameraRenderer): FotoapparatBuilder {
-        this.renderer = renderer
-        return this
-    }
+    fun into(renderer: CameraRenderer): FotoapparatBuilder =
+            apply { this.renderer = renderer }
 
     /**
      * @return set up instance of [Fotoapparat].

--- a/fotoapparat/src/main/java/io/fotoapparat/capability/provide/CapabilitiesProvider.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/capability/provide/CapabilitiesProvider.kt
@@ -21,7 +21,7 @@ private fun SupportedParameters.getCapabilities(): Capabilities {
             canSmoothZoom = supportedSmoothZoom,
             maxMeteringAreas = maxNumMeteringAreas,
             jpegQualityRange = jpegQualityRange,
-            antiBandingModes = supportedAutoBandingModes.extract { it.toAntiBandingMode() },
+            antiBandingModes = supportedAutoBandingModes.extract(String::toAntiBandingMode),
             sensorSensitivities = sensorSensitivities.toSet(),
             previewFpsRanges = supportedPreviewFpsRanges.extract { it.toFpsRange() },
             pictureResolutions = pictureResolutions.mapSizes(),

--- a/fotoapparat/src/main/java/io/fotoapparat/characteristic/LensPositionCharacteristic.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/characteristic/LensPositionCharacteristic.kt
@@ -12,13 +12,12 @@ import io.fotoapparat.exception.camera.CameraException
  * @return [LensPosition] from the given lens position code id.
  * `null` if position code id is not supported.
  */
-internal fun Int.toLensPosition(): LensPosition {
-    return when (this) {
-        Camera.CameraInfo.CAMERA_FACING_FRONT -> LensPosition.Front
-        Camera.CameraInfo.CAMERA_FACING_BACK -> LensPosition.Back
-        else -> throw IllegalArgumentException("Lens position $this is not supported.")
-    }
-}
+internal fun Int.toLensPosition(): LensPosition =
+        when (this) {
+            Camera.CameraInfo.CAMERA_FACING_FRONT -> LensPosition.Front
+            Camera.CameraInfo.CAMERA_FACING_BACK -> LensPosition.Back
+            else -> throw IllegalArgumentException("Lens position $this is not supported.")
+        }
 
 /**
  * Maps between [LensPosition] and Camera v1 code id.
@@ -26,10 +25,9 @@ internal fun Int.toLensPosition(): LensPosition {
  * @receiver [LensPosition]
  * @return code of the camera as in [Camera.CameraInfo].
  */
-fun LensPosition.toCameraId(): Int {
-    return (0 until Camera.getNumberOfCameras())
-            .find {
-                this == getCharacteristics(it).lensPosition
-            }
-            ?: throw CameraException("Device has no camera for the desired lens position(s).")
-}
+fun LensPosition.toCameraId(): Int =
+        (0 until Camera.getNumberOfCameras())
+                .find { cameraId ->
+                    this == getCharacteristics(cameraId).lensPosition
+                }
+                ?: throw CameraException("Device has no camera for the desired lens position(s).")

--- a/fotoapparat/src/main/java/io/fotoapparat/configuration/CameraConfiguration.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/configuration/CameraConfiguration.kt
@@ -38,67 +38,58 @@ data class CameraConfiguration(
 
         private var cameraConfiguration: CameraConfiguration = default()
 
-        fun flash(selector: FlashSelector): Builder {
+        fun flash(selector: FlashSelector): Builder = apply {
             cameraConfiguration = cameraConfiguration.copy(
                     flashMode = selector
             )
-            return this
         }
 
-        fun focusMode(selector: FocusModeSelector): Builder {
+        fun focusMode(selector: FocusModeSelector): Builder = apply {
             cameraConfiguration = cameraConfiguration.copy(
                     focusMode = selector
             )
-            return this
         }
 
-        fun previewFpsRange(selector: FpsRangeSelector): Builder {
+        fun previewFpsRange(selector: FpsRangeSelector): Builder = apply {
             cameraConfiguration = cameraConfiguration.copy(
                     previewFpsRange = selector
             )
-            return this
         }
 
-        fun sensorSensitivity(selector: SensorSensitivitySelector): Builder {
+        fun sensorSensitivity(selector: SensorSensitivitySelector): Builder = apply {
             cameraConfiguration = cameraConfiguration.copy(
                     sensorSensitivity = selector
             )
-            return this
         }
 
-        fun antiBandingMode(selector: AntiBandingModeSelector): Builder {
+        fun antiBandingMode(selector: AntiBandingModeSelector): Builder = apply {
             cameraConfiguration.copy(
                     antiBandingMode = selector
             )
-            return this
         }
 
-        fun jpegQuality(selector: QualitySelector): Builder {
+        fun jpegQuality(selector: QualitySelector): Builder = apply {
             cameraConfiguration.copy(
                     jpegQuality = selector
             )
-            return this
         }
 
-        fun previewResolution(selector: ResolutionSelector): Builder {
+        fun previewResolution(selector: ResolutionSelector): Builder = apply {
             cameraConfiguration = cameraConfiguration.copy(
                     previewResolution = selector
             )
-            return this
         }
 
-        fun photoResolution(selector: ResolutionSelector): Builder {
+        fun photoResolution(selector: ResolutionSelector): Builder = apply {
             cameraConfiguration = cameraConfiguration.copy(
                     pictureResolution = selector
             )
-            return this
         }
 
-        fun frameProcessor(frameProcessor: FrameProcessorJava): Builder {
+        fun frameProcessor(frameProcessor: FrameProcessorJava): Builder = apply {
             cameraConfiguration = cameraConfiguration.copy(
                     frameProcessor = frameProcessor::process
             )
-            return this
         }
 
         /**

--- a/fotoapparat/src/main/java/io/fotoapparat/configuration/CameraConfiguration.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/configuration/CameraConfiguration.kt
@@ -1,9 +1,8 @@
 package io.fotoapparat.configuration
 
-import io.fotoapparat.parameter.*
-import io.fotoapparat.preview.Frame
-import io.fotoapparat.preview.FrameProcessor
 import io.fotoapparat.selector.*
+import io.fotoapparat.util.FrameProcessor
+import io.fotoapparat.preview.FrameProcessor as FrameProcessorJava
 
 
 private const val DEFAULT_JPEG_QUALITY = 90
@@ -12,24 +11,24 @@ private const val DEFAULT_JPEG_QUALITY = 90
  * A camera configuration which has all it's selectors defined.
  */
 data class CameraConfiguration(
-        override val flashMode: Iterable<Flash>.() -> Flash? = off(),
-        override val focusMode: Iterable<FocusMode>.() -> FocusMode? = firstAvailable(
+        override val flashMode: FlashSelector = off(),
+        override val focusMode: FocusModeSelector = firstAvailable(
                 continuousFocusPicture(),
                 autoFocus(),
                 fixed()
         ),
-        override val jpegQuality: (IntRange) -> Int? = manualJpegQuality(DEFAULT_JPEG_QUALITY),
-        override val frameProcessor: (Frame) -> Unit = {},
-        override val previewFpsRange: Iterable<FpsRange>.() -> FpsRange? = highestFps(),
-        override val antiBandingMode: Iterable<AntiBandingMode>.() -> AntiBandingMode? = firstAvailable(
+        override val jpegQuality: QualitySelector = manualJpegQuality(DEFAULT_JPEG_QUALITY),
+        override val frameProcessor: FrameProcessor = {},
+        override val previewFpsRange: FpsRangeSelector = highestFps(),
+        override val antiBandingMode: AntiBandingModeSelector = firstAvailable(
                 auto(),
                 hz50(),
                 hz60(),
                 none()
         ),
-        override val sensorSensitivity: (Iterable<Int>.() -> Int?)? = null,
-        override val pictureResolution: Iterable<Resolution>.() -> Resolution? = highestResolution(),
-        override val previewResolution: Iterable<Resolution>.() -> Resolution? = highestResolution()
+        override val sensorSensitivity: SensorSensitivitySelector? = null,
+        override val pictureResolution: ResolutionSelector = highestResolution(),
+        override val previewResolution: ResolutionSelector = highestResolution()
 ) : Configuration {
 
     /**
@@ -39,65 +38,65 @@ data class CameraConfiguration(
 
         private var cameraConfiguration: CameraConfiguration = default()
 
-        fun flash(selector: (Iterable<Flash>.() -> Flash?)): Builder {
+        fun flash(selector: FlashSelector): Builder {
             cameraConfiguration = cameraConfiguration.copy(
                     flashMode = selector
             )
             return this
         }
 
-        fun focusMode(selector: (Iterable<FocusMode>.() -> FocusMode?)): Builder {
+        fun focusMode(selector: FocusModeSelector): Builder {
             cameraConfiguration = cameraConfiguration.copy(
                     focusMode = selector
             )
             return this
         }
 
-        fun previewFpsRange(selector: (Iterable<FpsRange>.() -> FpsRange?)): Builder {
+        fun previewFpsRange(selector: FpsRangeSelector): Builder {
             cameraConfiguration = cameraConfiguration.copy(
                     previewFpsRange = selector
             )
             return this
         }
 
-        fun sensorSensitivity(selector: (Iterable<Int>.() -> Int?)): Builder {
+        fun sensorSensitivity(selector: SensorSensitivitySelector): Builder {
             cameraConfiguration = cameraConfiguration.copy(
                     sensorSensitivity = selector
             )
             return this
         }
 
-        fun antiBandingMode(selector: Iterable<AntiBandingMode>.() -> AntiBandingMode?): Builder {
+        fun antiBandingMode(selector: AntiBandingModeSelector): Builder {
             cameraConfiguration.copy(
                     antiBandingMode = selector
             )
             return this
         }
 
-        fun jpegQuality(selector: IntRange.() -> Int?): Builder {
+        fun jpegQuality(selector: QualitySelector): Builder {
             cameraConfiguration.copy(
                     jpegQuality = selector
             )
             return this
         }
 
-        fun previewResolution(selector: (Iterable<Resolution>.() -> Resolution?)): Builder {
+        fun previewResolution(selector: ResolutionSelector): Builder {
             cameraConfiguration = cameraConfiguration.copy(
                     previewResolution = selector
             )
             return this
         }
 
-        fun photoResolution(selector: (Iterable<Resolution>.() -> Resolution?)): Builder {
+        fun photoResolution(selector: ResolutionSelector): Builder {
             cameraConfiguration = cameraConfiguration.copy(
                     pictureResolution = selector
             )
             return this
         }
 
-        fun frameProcessor(frameProcessor: FrameProcessor): Builder {
+        fun frameProcessor(frameProcessor: FrameProcessorJava): Builder {
             cameraConfiguration = cameraConfiguration.copy(
-                    frameProcessor = { frameProcessor.process(it) }
+                    frameProcessor = frameProcessor::process
             )
             return this
         }
@@ -115,18 +114,18 @@ data class CameraConfiguration(
          * Alias for [CameraConfiguration.default]
          */
         @JvmStatic
-        fun standard() = default()
+        fun standard(): CameraConfiguration = default()
 
         /**
          * Default [CameraConfiguration].
          */
         @JvmStatic
-        fun default() = CameraConfiguration()
+        fun default(): CameraConfiguration = CameraConfiguration()
 
         /**
          * Creates a new [CameraConfiguration.Builder].
          */
         @JvmStatic
-        fun builder() = CameraConfiguration.Builder()
+        fun builder(): Builder = Builder()
     }
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/configuration/Configuration.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/configuration/Configuration.kt
@@ -1,16 +1,16 @@
 package io.fotoapparat.configuration
 
-import io.fotoapparat.parameter.*
-import io.fotoapparat.preview.Frame
+import io.fotoapparat.selector.*
+import io.fotoapparat.util.FrameProcessor
 
 interface Configuration {
-    val flashMode: (Iterable<Flash>.() -> Flash?)?
-    val focusMode: (Iterable<FocusMode>.() -> FocusMode?)?
-    val jpegQuality: ((IntRange) -> Int?)?
-    val frameProcessor: ((Frame) -> Unit)?
-    val previewFpsRange: (Iterable<FpsRange>.() -> FpsRange?)?
-    val antiBandingMode: (Iterable<AntiBandingMode>.() -> AntiBandingMode?)?
-    val sensorSensitivity: (Iterable<Int>.() -> Int?)?
-    val previewResolution: (Iterable<Resolution>.() -> Resolution?)?
-    val pictureResolution: (Iterable<Resolution>.() -> Resolution?)?
+    val flashMode: FlashSelector?
+    val focusMode: FocusModeSelector?
+    val jpegQuality: QualitySelector?
+    val frameProcessor: FrameProcessor?
+    val previewFpsRange: FpsRangeSelector?
+    val antiBandingMode: AntiBandingModeSelector?
+    val sensorSensitivity: SensorSensitivitySelector?
+    val previewResolution: ResolutionSelector?
+    val pictureResolution: ResolutionSelector?
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/configuration/UpdateConfiguration.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/configuration/UpdateConfiguration.kt
@@ -1,21 +1,21 @@
 package io.fotoapparat.configuration
 
-import io.fotoapparat.parameter.*
-import io.fotoapparat.preview.Frame
+import io.fotoapparat.selector.*
+import io.fotoapparat.util.FrameProcessor
 
 /**
  * A camera update configuration.
  */
 data class UpdateConfiguration(
-        override val flashMode: (Iterable<Flash>.() -> Flash?)? = null,
-        override val focusMode: (Iterable<FocusMode>.() -> FocusMode?)? = null,
-        override val jpegQuality: ((IntRange) -> Int?)? = null,
-        override val frameProcessor: ((Frame) -> Unit)? = null,
-        override val previewFpsRange: (Iterable<FpsRange>.() -> FpsRange?)? = null,
-        override val antiBandingMode: (Iterable<AntiBandingMode>.() -> AntiBandingMode?)? = null,
-        override val sensorSensitivity: (Iterable<Int>.() -> Int?)? = null,
-        override val previewResolution: (Iterable<Resolution>.() -> Resolution?)? = null,
-        override val pictureResolution: (Iterable<Resolution>.() -> Resolution?)? = null
+        override val flashMode: FlashSelector? = null,
+        override val focusMode: FocusModeSelector? = null,
+        override val jpegQuality: QualitySelector? = null,
+        override val frameProcessor: FrameProcessor? = null,
+        override val previewFpsRange: FpsRangeSelector? = null,
+        override val antiBandingMode: AntiBandingModeSelector? = null,
+        override val sensorSensitivity: SensorSensitivitySelector? = null,
+        override val previewResolution: ResolutionSelector? = null,
+        override val pictureResolution: ResolutionSelector? = null
 ) : Configuration {
 
     /**
@@ -25,67 +25,58 @@ data class UpdateConfiguration(
 
         private var configuration = UpdateConfiguration()
 
-        fun flash(selector: Iterable<Flash>.() -> Flash?): Builder {
+        fun flash(selector: FlashSelector): Builder = apply {
             configuration.copy(
                     flashMode = selector
             )
-            return this
         }
 
-        fun focusMode(selector: Iterable<FocusMode>.() -> FocusMode?): Builder {
+        fun focusMode(selector: FocusModeSelector): Builder = apply {
             configuration.copy(
                     focusMode = selector
             )
-            return this
         }
 
-        fun previewFpsRange(selector: Iterable<FpsRange>.() -> FpsRange?): Builder {
+        fun previewFpsRange(selector: FpsRangeSelector): Builder = apply {
             configuration.copy(
                     previewFpsRange = selector
             )
-            return this
         }
 
-        fun sensorSensitivity(selector: Iterable<Int>.() -> Int?): Builder {
+        fun sensorSensitivity(selector: SensorSensitivitySelector): Builder = apply {
             configuration.copy(
                     sensorSensitivity = selector
             )
-            return this
         }
 
-        fun antiBandingMode(selector: Iterable<AntiBandingMode>.() -> AntiBandingMode?): Builder {
+        fun antiBandingMode(selector: AntiBandingModeSelector): Builder = apply {
             configuration.copy(
                     antiBandingMode = selector
             )
-            return this
         }
 
-        fun jpegQuality(selector: IntRange.() -> Int?): Builder {
+        fun jpegQuality(selector: QualitySelector): Builder = apply {
             configuration.copy(
                     jpegQuality = selector
             )
-            return this
         }
 
-        fun previewResolution(selector: Iterable<Resolution>.() -> Resolution?): Builder {
+        fun previewResolution(selector: ResolutionSelector): Builder = apply {
             configuration.copy(
                     previewResolution = selector
             )
-            return this
         }
 
-        fun photoResolution(selector: Iterable<Resolution>.() -> Resolution?): Builder {
+        fun photoResolution(selector: ResolutionSelector): Builder = apply {
             configuration.copy(
                     pictureResolution = selector
             )
-            return this
         }
 
-        fun frameProcessor(frameProcessor: (Frame) -> Unit): Builder {
+        fun frameProcessor(frameProcessor: FrameProcessor): Builder = apply {
             configuration.copy(
                     frameProcessor = frameProcessor
             )
-            return this
         }
 
         /**
@@ -100,6 +91,6 @@ data class UpdateConfiguration(
          * Creates a new [UpdateConfiguration.Builder].
          */
         @JvmStatic
-        fun builder() = UpdateConfiguration.Builder()
+        fun builder(): Builder = Builder()
     }
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/coroutines/AwaitBroadcastChannel.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/coroutines/AwaitBroadcastChannel.kt
@@ -10,24 +10,24 @@ import kotlinx.coroutines.experimental.channels.ConflatedBroadcastChannel
  */
 internal class AwaitBroadcastChannel<T>(
         private val channel: ConflatedBroadcastChannel<T> = ConflatedBroadcastChannel(),
-        private val defered: CompletableDeferred<Boolean> = CompletableDeferred()
-) : BroadcastChannel<T> by channel, Deferred<Boolean> by defered {
+        private val deferred: CompletableDeferred<Boolean> = CompletableDeferred()
+) : BroadcastChannel<T> by channel, Deferred<Boolean> by deferred {
 
     /**
      * The most recently sent element to this channel.
      */
     suspend fun getValue(): T {
-        defered.await()
+        deferred.await()
         return channel.value
     }
 
     override fun offer(element: T): Boolean {
-        defered.complete(true)
+        deferred.complete(true)
         return channel.offer(element)
     }
 
-    suspend override fun send(element: T) {
-        defered.complete(true)
+    override suspend fun send(element: T) {
+        deferred.complete(true)
         channel.send(element)
     }
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/error/ErrorCallbacks.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/error/ErrorCallbacks.kt
@@ -4,10 +4,13 @@ import android.os.Looper
 import io.fotoapparat.exception.camera.CameraException
 import io.fotoapparat.hardware.executeMainThread
 
+
+typealias CameraErrorCallback = (CameraException) -> Unit
+
 /**
  * @return CameraErrorCallback which will always move execution to the main thread.
  */
-fun ((CameraException) -> Unit).onMainThread(): (CameraException) -> Unit = { cameraException ->
+fun CameraErrorCallback.onMainThread(): CameraErrorCallback = { cameraException ->
     if (Looper.myLooper() == Looper.getMainLooper()) {
         this(cameraException)
     } else {

--- a/fotoapparat/src/main/java/io/fotoapparat/exif/ExifWriter.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/exif/ExifWriter.kt
@@ -11,16 +11,16 @@ import java.io.IOException
  */
 internal object ExifWriter : ExifOrientationWriter {
 
-
     @Throws(FileSaveException::class)
     override fun writeExifOrientation(file: File, photo: Photo) {
         try {
-            val exifInterface = ExifInterface(file.path)
-            exifInterface.setAttribute(
-                    ExifInterface.TAG_ORIENTATION,
-                    toExifOrientation(photo.rotationDegrees).toString()
-            )
-            exifInterface.saveAttributes()
+            ExifInterface(file.path).apply {
+                setAttribute(
+                        ExifInterface.TAG_ORIENTATION,
+                        toExifOrientation(photo.rotationDegrees).toString()
+                )
+                saveAttributes()
+            }
         } catch (e: IOException) {
             throw FileSaveException(e)
         }

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/display/Display.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/display/Display.kt
@@ -7,7 +7,7 @@ import android.view.WindowManager
 /**
  * A phone's display.
  */
-open internal class Display(context: Context) {
+internal open class Display(context: Context) {
 
     private val display = context.getDisplay()
 

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/orientation/OrientationSensor.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/orientation/OrientationSensor.kt
@@ -7,7 +7,7 @@ import io.fotoapparat.hardware.Device
 /**
  * Monitors orientation of the device.
  */
-open internal class OrientationSensor(
+internal open class OrientationSensor(
         private val rotationListener: RotationListener,
         private val device: Device
 ) {

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/orientation/RotationListener.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/orientation/RotationListener.kt
@@ -7,7 +7,7 @@ import android.view.OrientationEventListener
 /**
  * Wrapper around [OrientationEventListener] to notify when the device's rotation has changed.
  */
-open internal class RotationListener(
+internal open class RotationListener(
         context: Context
 ) : OrientationEventListener(context) {
 

--- a/fotoapparat/src/main/java/io/fotoapparat/log/FileLogger.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/log/FileLogger.kt
@@ -9,9 +9,7 @@ import java.io.IOException
  */
 class FileLogger(private val file: File) : Logger {
 
-    private val writer: FileWriter by lazy {
-        FileWriter(file)
-    }
+    private val writer: FileWriter by lazy { FileWriter(file) }
 
     override fun log(message: String) {
         try {

--- a/fotoapparat/src/main/java/io/fotoapparat/log/Loggers.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/log/Loggers.kt
@@ -19,11 +19,7 @@ fun logcat(): Logger = LogcatLogger()
  *
  * Note: if file is not writable, no errors will be produced.
  */
-fun fileLogger(file: File): Logger {
-    return BackgroundThreadLogger(
-            FileLogger(file)
-    )
-}
+fun fileLogger(file: File): Logger = BackgroundThreadLogger(FileLogger(file))
 
 /**
  * @return logger which prints logs to file located at `context.getExternalFilesDir("logs")`.

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/Resolution.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/Resolution.kt
@@ -6,26 +6,19 @@ import android.support.annotation.IntRange
  * Resolution. Units in pixels.
  */
 data class Resolution(
-
-        @JvmField
-        @IntRange(from = 0L, to = Long.MAX_VALUE)
-        val width: Int,
-        @JvmField
-        @IntRange(from = 0L, to = Long.MAX_VALUE)
-        val height: Int
+        @[JvmField IntRange(from = 0L)] val width: Int,
+        @[JvmField IntRange(from = 0L)] val height: Int
 ) : Parameter {
 
     /**
      * The total area this [Resolution] is covering.
      */
-    val area by lazy {
-        width * height
-    }
+    val area: Int by lazy { width * height }
 
     /**
      * The aspect ratio for this size. [Float.NaN] if invalid dimensions.
      */
-    val aspectRatio by lazy {
+    val aspectRatio: Float by lazy {
         when {
             width == 0 -> Float.NaN
             height == 0 -> Float.NaN
@@ -36,6 +29,6 @@ data class Resolution(
     /**
      * @return new instance of [Resolution] with width and height being swapped.
      */
-    fun flipDimensions() = Resolution(height, width)
+    fun flipDimensions(): Resolution = Resolution(height, width)
 
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/camera/convert/AntiBandingConverter.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/camera/convert/AntiBandingConverter.kt
@@ -11,15 +11,14 @@ import io.fotoapparat.parameter.AntiBandingMode
  * @receiver Code of the anti banding mode as in [Camera.Parameters].
  * @return The [io.fotoapparat.Fotoapparat]'s camera [AntiBandingMode]. `null` if camera code is not supported.
  */
-fun String.toAntiBandingMode(): AntiBandingMode? {
-    return when (this) {
-        Camera.Parameters.ANTIBANDING_AUTO -> AntiBandingMode.Auto
-        Camera.Parameters.ANTIBANDING_50HZ -> AntiBandingMode.HZ50
-        Camera.Parameters.ANTIBANDING_60HZ -> AntiBandingMode.HZ60
-        Camera.Parameters.ANTIBANDING_OFF -> AntiBandingMode.None
-        else -> null
-    }
-}
+fun String.toAntiBandingMode(): AntiBandingMode? =
+        when (this) {
+            Camera.Parameters.ANTIBANDING_AUTO -> AntiBandingMode.Auto
+            Camera.Parameters.ANTIBANDING_50HZ -> AntiBandingMode.HZ50
+            Camera.Parameters.ANTIBANDING_60HZ -> AntiBandingMode.HZ60
+            Camera.Parameters.ANTIBANDING_OFF -> AntiBandingMode.None
+            else -> null
+        }
 
 /**
  * Converts a [AntiBandingMode] to a antiBandingMode mode code as in [Camera.Parameters].
@@ -27,11 +26,10 @@ fun String.toAntiBandingMode(): AntiBandingMode? {
  * @receiver The [io.fotoapparat.Fotoapparat]'s camera [AntiBandingMode].
  * @return anti banding mode code as in [Camera.Parameters].
  */
-fun AntiBandingMode.toCode(): String {
-    return when (this) {
-        AntiBandingMode.Auto -> Camera.Parameters.ANTIBANDING_AUTO
-        AntiBandingMode.HZ50 -> Camera.Parameters.ANTIBANDING_50HZ
-        AntiBandingMode.HZ60 -> Camera.Parameters.ANTIBANDING_60HZ
-        AntiBandingMode.None -> Camera.Parameters.ANTIBANDING_OFF
-    }
-}
+fun AntiBandingMode.toCode(): String =
+        when (this) {
+            AntiBandingMode.Auto -> Camera.Parameters.ANTIBANDING_AUTO
+            AntiBandingMode.HZ50 -> Camera.Parameters.ANTIBANDING_50HZ
+            AntiBandingMode.HZ60 -> Camera.Parameters.ANTIBANDING_60HZ
+            AntiBandingMode.None -> Camera.Parameters.ANTIBANDING_OFF
+        }

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/camera/convert/FlashConverter.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/camera/convert/FlashConverter.kt
@@ -11,16 +11,15 @@ import io.fotoapparat.parameter.Flash
  * @receiver Code of flash mode as in [Camera.Parameters].
  * @return [Flash] from given camera code. `null` if camera code is not supported.
  */
-internal fun String.toFlash(): Flash? {
-    return when (this) {
-        Camera.Parameters.FLASH_MODE_ON -> Flash.On
-        Camera.Parameters.FLASH_MODE_OFF -> Flash.Off
-        Camera.Parameters.FLASH_MODE_AUTO -> Flash.Auto
-        Camera.Parameters.FLASH_MODE_TORCH -> Flash.Torch
-        Camera.Parameters.FLASH_MODE_RED_EYE -> Flash.AutoRedEye
-        else -> null
-    }
-}
+internal fun String.toFlash(): Flash? =
+        when (this) {
+            Camera.Parameters.FLASH_MODE_ON -> Flash.On
+            Camera.Parameters.FLASH_MODE_OFF -> Flash.Off
+            Camera.Parameters.FLASH_MODE_AUTO -> Flash.Auto
+            Camera.Parameters.FLASH_MODE_TORCH -> Flash.Torch
+            Camera.Parameters.FLASH_MODE_RED_EYE -> Flash.AutoRedEye
+            else -> null
+        }
 
 /**
  * Maps between [Flash] and Camera v1 flash codes.
@@ -28,12 +27,11 @@ internal fun String.toFlash(): Flash? {
  * @receiver Flash mode.
  * @return code of the flash mode as in [Camera.Parameters].
  */
-internal fun Flash.toCode(): String {
-    return when (this) {
-        Flash.On -> Camera.Parameters.FLASH_MODE_ON
-        Flash.Off -> Camera.Parameters.FLASH_MODE_OFF
-        Flash.Auto -> Camera.Parameters.FLASH_MODE_AUTO
-        Flash.Torch -> Camera.Parameters.FLASH_MODE_TORCH
-        Flash.AutoRedEye -> Camera.Parameters.FLASH_MODE_RED_EYE
-    }
-}
+internal fun Flash.toCode(): String =
+        when (this) {
+            Flash.On -> Camera.Parameters.FLASH_MODE_ON
+            Flash.Off -> Camera.Parameters.FLASH_MODE_OFF
+            Flash.Auto -> Camera.Parameters.FLASH_MODE_AUTO
+            Flash.Torch -> Camera.Parameters.FLASH_MODE_TORCH
+            Flash.AutoRedEye -> Camera.Parameters.FLASH_MODE_RED_EYE
+        }

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/camera/convert/FocusModeConverter.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/camera/convert/FocusModeConverter.kt
@@ -12,18 +12,17 @@ import io.fotoapparat.parameter.FocusMode
  * @receiver Code of focus mode as in [Camera.Parameters].
  * @return [FocusMode] from given camera code. `null` if camera code is not supported.
  */
-internal fun String.toFocusMode(): FocusMode? {
-    return when (this) {
-        Camera.Parameters.FOCUS_MODE_EDOF -> FocusMode.Edof
-        Camera.Parameters.FOCUS_MODE_AUTO -> FocusMode.Auto
-        Camera.Parameters.FOCUS_MODE_MACRO -> FocusMode.Macro
-        Camera.Parameters.FOCUS_MODE_FIXED -> FocusMode.Fixed
-        Camera.Parameters.FOCUS_MODE_INFINITY -> FocusMode.Infinity
-        Camera.Parameters.FOCUS_MODE_CONTINUOUS_VIDEO -> FocusMode.ContinuousFocusVideo
-        Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE -> FocusMode.ContinuousFocusPicture
-        else -> null
-    }
-}
+internal fun String.toFocusMode(): FocusMode? =
+        when (this) {
+            Camera.Parameters.FOCUS_MODE_EDOF -> FocusMode.Edof
+            Camera.Parameters.FOCUS_MODE_AUTO -> FocusMode.Auto
+            Camera.Parameters.FOCUS_MODE_MACRO -> FocusMode.Macro
+            Camera.Parameters.FOCUS_MODE_FIXED -> FocusMode.Fixed
+            Camera.Parameters.FOCUS_MODE_INFINITY -> FocusMode.Infinity
+            Camera.Parameters.FOCUS_MODE_CONTINUOUS_VIDEO -> FocusMode.ContinuousFocusVideo
+            Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE -> FocusMode.ContinuousFocusPicture
+            else -> null
+        }
 
 /**
  * Maps between [FocusMode] and Camera v1 focus codes.
@@ -31,14 +30,13 @@ internal fun String.toFocusMode(): FocusMode? {
  * @receiver FocusMode mode.
  * @return code of the focus mode as in [Camera.Parameters].
  */
-internal fun FocusMode.toCode(): String {
-    return when (this) {
-        FocusMode.Edof -> Camera.Parameters.FOCUS_MODE_EDOF
-        FocusMode.Auto -> Camera.Parameters.FOCUS_MODE_AUTO
-        FocusMode.Macro -> Camera.Parameters.FOCUS_MODE_MACRO
-        FocusMode.Fixed -> Camera.Parameters.FOCUS_MODE_FIXED
-        FocusMode.Infinity -> Camera.Parameters.FOCUS_MODE_INFINITY
-        FocusMode.ContinuousFocusVideo -> Camera.Parameters.FOCUS_MODE_CONTINUOUS_VIDEO
-        FocusMode.ContinuousFocusPicture -> Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE
-    }
-}
+internal fun FocusMode.toCode(): String =
+        when (this) {
+            FocusMode.Edof -> Camera.Parameters.FOCUS_MODE_EDOF
+            FocusMode.Auto -> Camera.Parameters.FOCUS_MODE_AUTO
+            FocusMode.Macro -> Camera.Parameters.FOCUS_MODE_MACRO
+            FocusMode.Fixed -> Camera.Parameters.FOCUS_MODE_FIXED
+            FocusMode.Infinity -> Camera.Parameters.FOCUS_MODE_INFINITY
+            FocusMode.ContinuousFocusVideo -> Camera.Parameters.FOCUS_MODE_CONTINUOUS_VIDEO
+            FocusMode.ContinuousFocusPicture -> Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE
+        }

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/camera/convert/FpsRangeConverter.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/camera/convert/FpsRangeConverter.kt
@@ -8,9 +8,8 @@ import io.fotoapparat.parameter.FpsRange
 /**
  * Converts a [IntArray] into a [FpsRange].
  */
-internal fun IntArray.toFpsRange(): FpsRange {
-    return FpsRange(
-            this[Camera.Parameters.PREVIEW_FPS_MIN_INDEX],
-            this[Camera.Parameters.PREVIEW_FPS_MAX_INDEX]
-    )
-}
+internal fun IntArray.toFpsRange(): FpsRange =
+        FpsRange(
+                this[Camera.Parameters.PREVIEW_FPS_MIN_INDEX],
+                this[Camera.Parameters.PREVIEW_FPS_MAX_INDEX]
+        )

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/camera/convert/ResolutionConverter.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/camera/convert/ResolutionConverter.kt
@@ -8,9 +8,4 @@ import io.fotoapparat.parameter.Resolution
 /**
  * Converts [Camera.Size] to [Resolution].
  */
-fun Camera.Size.toResolution(): Resolution {
-    return Resolution(
-            width,
-            height
-    )
-}
+fun Camera.Size.toResolution(): Resolution = Resolution(width, height)

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/extract/RawValuesExtractor.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/extract/RawValuesExtractor.kt
@@ -10,14 +10,12 @@ import android.hardware.Camera
  * Empty list of values will be returned
  */
 internal fun Camera.Parameters.extractRawCameraValues(keys: List<String>): List<String> {
-    keys.forEach {
-        getValuesForKey(key = it)
-                ?.let { return it }
+    keys.forEach { key ->
+        getValuesForKey(key)?.let { params -> return params }
     }
 
     return emptyList()
 }
 
-private fun Camera.Parameters.getValuesForKey(key: String): List<String>? {
-    return get(key)?.split(regex = ",".toRegex())
-}
+private fun Camera.Parameters.getValuesForKey(key: String): List<String>? =
+        get(key)?.split(regex = ",".toRegex())

--- a/fotoapparat/src/main/java/io/fotoapparat/result/Photo.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/result/Photo.kt
@@ -24,29 +24,25 @@ data class Photo(
         val rotationDegrees: Int
 ) {
 
+    /**
+     * The height of the photo.
+     */
+    val height by lazy { decodedBounds.height }
+
+    /**
+     * The width of the photo.
+     */
+    val width by lazy { decodedBounds.width }
+
     private val decodedBounds by lazy {
         BitmapFactory.decodeByteArray(
                 encodedImage,
                 0,
                 encodedImage.size,
                 BitmapFactory.Options().apply {
-                    inJustDecodeBounds = true
-                }
+                            inJustDecodeBounds = true
+                        }
         )
-    }
-
-    /**
-     * The height of the photo.
-     */
-    val height by lazy {
-        decodedBounds.height
-    }
-
-    /**
-     * The width of the photo.
-     */
-    val width by lazy {
-        decodedBounds.width
     }
 
     override fun equals(other: Any?): Boolean {
@@ -69,15 +65,12 @@ data class Photo(
 
     companion object {
 
+        private val EMPTY by lazy { Photo(encodedImage = ByteArray(0), rotationDegrees = 0) }
+
         /**
          * @return empty [Photo].
          */
-        internal fun empty(): Photo {
-            return Photo(
-                    encodedImage = ByteArray(0),
-                    rotationDegrees = 0
-            )
-        }
+        internal fun empty(): Photo = EMPTY
     }
 
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/result/PhotoResult.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/result/PhotoResult.kt
@@ -4,8 +4,8 @@ import android.graphics.Bitmap
 import io.fotoapparat.exception.FileSaveException
 import io.fotoapparat.exif.ExifWriter
 import io.fotoapparat.log.Logger
-import io.fotoapparat.parameter.Resolution
 import io.fotoapparat.result.transformer.BitmapPhotoTransformer
+import io.fotoapparat.result.transformer.ResolutionTransformer
 import io.fotoapparat.result.transformer.SaveToFileTransformer
 import io.fotoapparat.result.transformer.originalResolution
 import java.io.File
@@ -25,9 +25,10 @@ class PhotoResult internal constructor(private val pendingResult: PendingResult<
      * future.
      */
     @JvmOverloads
-    fun toBitmap(sizeTransformer: (Resolution) -> Resolution = originalResolution()): PendingResult<BitmapPhoto> {
-        return pendingResult.transform(BitmapPhotoTransformer(sizeTransformer))
-    }
+    fun toBitmap(
+            sizeTransformer: ResolutionTransformer = originalResolution()
+    ): PendingResult<BitmapPhoto> =
+            pendingResult.transform(BitmapPhotoTransformer(sizeTransformer))
 
     /**
      * Saves result to file.
@@ -35,19 +36,16 @@ class PhotoResult internal constructor(private val pendingResult: PendingResult<
      * @return pending operation which completes when photo is saved to file.
      * @throws FileSaveException If the file cannot be saved.
      */
-    fun saveToFile(file: File): PendingResult<Unit> {
-        return pendingResult.transform(SaveToFileTransformer(
-                file = file,
-                exifOrientationWriter = ExifWriter
-        ))
-    }
+    fun saveToFile(file: File): PendingResult<Unit> =
+            pendingResult.transform(SaveToFileTransformer(
+                    file = file,
+                    exifOrientationWriter = ExifWriter
+            ))
 
     /**
      * @return result as [PendingResult].
      */
-    fun toPendingResult(): PendingResult<Photo> {
-        return pendingResult
-    }
+    fun toPendingResult(): PendingResult<Photo> = pendingResult
 
     companion object {
 

--- a/fotoapparat/src/main/java/io/fotoapparat/result/transformer/BitmapPhotoTransformer.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/result/transformer/BitmapPhotoTransformer.kt
@@ -11,7 +11,7 @@ import io.fotoapparat.result.Photo
  * Creates [BitmapPhoto] out of [Photo].
  */
 internal class BitmapPhotoTransformer(
-        private val sizeTransformer: (Resolution) -> Resolution
+        private val sizeTransformer: ResolutionTransformer
 ) : (Photo) -> BitmapPhoto {
 
     override fun invoke(input: Photo): BitmapPhoto {
@@ -23,9 +23,7 @@ internal class BitmapPhotoTransformer(
                 desiredResolution = desiredResolution
         )
 
-        val decodedBitmap = input.decodeBitmap(scaleFactor)
-
-        decodedBitmap ?: throw UnableToDecodeBitmapException()
+        val decodedBitmap = input.decodeBitmap(scaleFactor) ?: throw UnableToDecodeBitmapException()
 
         val bitmap = if (decodedBitmap.width == desiredResolution.width && decodedBitmap.height == desiredResolution.height) {
             decodedBitmap
@@ -77,9 +75,7 @@ private fun Photo.readResolution(): Resolution {
 private fun computeScaleFactor(
         originalResolution: Resolution,
         desiredResolution: Resolution
-): Float {
-    return Math.min(
-            originalResolution.width / desiredResolution.width.toFloat(),
-            originalResolution.height / desiredResolution.height.toFloat()
-    )
-}
+): Float = Math.min(
+        originalResolution.width / desiredResolution.width.toFloat(),
+        originalResolution.height / desiredResolution.height.toFloat()
+)

--- a/fotoapparat/src/main/java/io/fotoapparat/result/transformer/ResolutionTransformers.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/result/transformer/ResolutionTransformers.kt
@@ -3,18 +3,18 @@ package io.fotoapparat.result.transformer
 import io.fotoapparat.parameter.Resolution
 
 
+typealias ResolutionTransformer = (Resolution) -> Resolution
+
 /**
  * @return Transforming function which always returns the same size as it receives.
  */
-fun originalResolution(): (Resolution) -> Resolution = {
-    it
-}
+fun originalResolution(): ResolutionTransformer = { it }
 
 /**
  * @param scaleFactor scale factor which would be applied to image.
  * @return Transforming function which returns size scaled by given factor.
  */
-fun scaled(scaleFactor: Float): (Resolution) -> Resolution = { input ->
+fun scaled(scaleFactor: Float): ResolutionTransformer = { input ->
     Resolution(
             width = (input.width * scaleFactor).toInt(),
             height = (input.height * scaleFactor).toInt()

--- a/fotoapparat/src/main/java/io/fotoapparat/routine/camera/StartRoutine.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/routine/camera/StartRoutine.kt
@@ -1,5 +1,6 @@
 package io.fotoapparat.routine.camera
 
+import io.fotoapparat.error.CameraErrorCallback
 import io.fotoapparat.exception.camera.CameraException
 import io.fotoapparat.hardware.Device
 import io.fotoapparat.hardware.executeTask
@@ -12,7 +13,7 @@ import io.fotoapparat.routine.orientation.startOrientationMonitoring
  */
 internal fun Device.bootStart(
         orientationSensor: OrientationSensor,
-        mainThreadErrorCallback: (CameraException) -> Unit
+        mainThreadErrorCallback: CameraErrorCallback
 ) {
     if (hasSelectedCamera()) {
         throw IllegalStateException("Camera has already started!")
@@ -57,9 +58,9 @@ internal fun Device.start() {
         )
     }
 
-    focusPointSelector?.setFocalPointListener {
+    focusPointSelector?.setFocalPointListener { focalRequest ->
         executeTask(Runnable {
-            focusOnPoint(it)
+            focusOnPoint(focalRequest)
         })
     }
 

--- a/fotoapparat/src/main/java/io/fotoapparat/routine/camera/SwitchCameraRoutine.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/routine/camera/SwitchCameraRoutine.kt
@@ -2,9 +2,11 @@ package io.fotoapparat.routine.camera
 
 import io.fotoapparat.characteristic.LensPosition
 import io.fotoapparat.configuration.CameraConfiguration
+import io.fotoapparat.error.CameraErrorCallback
 import io.fotoapparat.exception.camera.CameraException
 import io.fotoapparat.hardware.CameraDevice
 import io.fotoapparat.hardware.Device
+import io.fotoapparat.selector.LensPositionSelector
 
 /**
  * Switches to a new [LensPosition] camera. Will do nothing if [LensPosition] is same.
@@ -12,9 +14,9 @@ import io.fotoapparat.hardware.Device
  * Will restart preview automatically if existing camera has started its preview.
  */
 internal fun Device.switchCamera(
-        newLensPositionSelector: Collection<LensPosition>.() -> LensPosition?,
+        newLensPositionSelector: LensPositionSelector,
         newConfiguration: CameraConfiguration,
-        mainThreadErrorCallback: (CameraException) -> Unit
+        mainThreadErrorCallback: CameraErrorCallback
 ) {
     val oldCameraDevice = try {
         getSelectedCamera()
@@ -41,7 +43,7 @@ internal fun Device.switchCamera(
  */
 internal fun Device.restartPreview(
         oldCameraDevice: CameraDevice,
-        mainThreadErrorCallback: (CameraException) -> Unit
+        mainThreadErrorCallback: CameraErrorCallback
 ) {
     stop(oldCameraDevice)
 

--- a/fotoapparat/src/main/java/io/fotoapparat/routine/photo/TakePhotoRoutine.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/routine/photo/TakePhotoRoutine.kt
@@ -20,7 +20,6 @@ internal fun Device.takePhoto(): Photo = runBlocking {
 private fun CameraDevice.startPreviewSafely() {
     try {
         startPreview()
-    } catch (e: CameraException) {
-        //Nothing
+    } catch (ignore: CameraException) {
     }
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/routine/zoom/UpdateZoomLevelRoutine.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/routine/zoom/UpdateZoomLevelRoutine.kt
@@ -23,7 +23,7 @@ internal fun Device.updateZoomLevel(
 }
 
 private fun Float.ensureInBounds() {
-    if (this < 0f || this > 1f) {
+    if (this !in 0f..1f) {
         throw LevelOutOfRangeException(this)
     }
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/selector/AntiBandingModeSelectors.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/selector/AntiBandingModeSelectors.kt
@@ -3,35 +3,30 @@ package io.fotoapparat.selector
 import io.fotoapparat.parameter.AntiBandingMode
 
 
+typealias AntiBandingModeSelector = Iterable<AntiBandingMode>.() -> AntiBandingMode?
+
 /**
  * @return Selector function which provides an auto anti banding mode if available.
  * Otherwise provides `null`.
  */
-fun auto(): Iterable<AntiBandingMode>.() -> AntiBandingMode? {
-    return single(AntiBandingMode.Auto)
-}
+fun auto(): AntiBandingModeSelector = single(AntiBandingMode.Auto)
+
 
 /**
  * @return Selector function which provides a 50hz banding mode if available.
  * Otherwise provides `null`.
  */
-fun hz50(): Iterable<AntiBandingMode>.() -> AntiBandingMode? {
-    return single(AntiBandingMode.HZ50)
-}
+fun hz50(): AntiBandingModeSelector = single(AntiBandingMode.HZ50)
 
 /**
  * @return Selector function which provides a 60hz anti banding mode if available.
  * Otherwise provides `null`.
  */
-fun hz60(): Iterable<AntiBandingMode>.() -> AntiBandingMode? {
-    return single(AntiBandingMode.HZ60)
-}
+fun hz60(): AntiBandingModeSelector = single(AntiBandingMode.HZ60)
 
 /**
  * @return Selector function which provides a disabled anti banding mode if available.
  * Otherwise provides `null`.
  */
-fun none(): Iterable<AntiBandingMode>.() -> AntiBandingMode? {
-    return single(AntiBandingMode.None)
-}
+fun none(): AntiBandingModeSelector = single(AntiBandingMode.None)
 

--- a/fotoapparat/src/main/java/io/fotoapparat/selector/AspectRatioSelectors.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/selector/AspectRatioSelectors.kt
@@ -1,7 +1,6 @@
 package io.fotoapparat.selector
 
 import android.support.annotation.FloatRange
-import io.fotoapparat.parameter.Resolution
 
 /**
  * @param selector Input selector
@@ -11,15 +10,13 @@ import io.fotoapparat.parameter.Resolution
  */
 @JvmOverloads
 fun standardRatio(
-        selector: Iterable<Resolution>.() -> Resolution?,
+        selector: ResolutionSelector,
         @FloatRange(from = 0.0, to = 1.0) tolerance: Double = 0.0
-): Iterable<Resolution>.() -> Resolution? {
-    return aspectRatio(
-            aspectRatio = 4f / 3f,
-            selector = selector,
-            tolerance = tolerance
-    )
-}
+): ResolutionSelector = aspectRatio(
+        aspectRatio = 4f / 3f,
+        selector = selector,
+        tolerance = tolerance
+)
 
 /**
  * @param selector Input sizes, selected by provided selector function
@@ -29,15 +26,13 @@ fun standardRatio(
  */
 @JvmOverloads
 fun wideRatio(
-        selector: Iterable<Resolution>.() -> Resolution?,
+        selector: ResolutionSelector,
         @FloatRange(from = 0.0, to = 1.0) tolerance: Double = 0.0
-): Iterable<Resolution>.() -> Resolution? {
-    return aspectRatio(
-            aspectRatio = 16f / 9f,
-            selector = selector,
-            tolerance = tolerance
-    )
-}
+): ResolutionSelector = aspectRatio(
+        aspectRatio = 16f / 9f,
+        selector = selector,
+        tolerance = tolerance
+)
 
 /**
  * Select sizes with desired aspect ratio. This selector can
@@ -51,9 +46,9 @@ fun wideRatio(
 @JvmOverloads
 fun aspectRatio(
         aspectRatio: Float,
-        selector: Iterable<Resolution>.() -> Resolution?,
+        selector: ResolutionSelector,
         @FloatRange(from = 0.0, to = 1.0) tolerance: Double = 0.0
-): Iterable<Resolution>.() -> Resolution? {
+): ResolutionSelector {
     if (tolerance !in 0.0..1.0) {
         throw IllegalArgumentException("Tolerance must be between 0.0 and 1.0.")
     }

--- a/fotoapparat/src/main/java/io/fotoapparat/selector/FlashSelectors.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/selector/FlashSelectors.kt
@@ -2,45 +2,36 @@ package io.fotoapparat.selector
 
 import io.fotoapparat.parameter.Flash
 
+typealias FlashSelector = Iterable<Flash>.() -> Flash?
 
 /**
  * @return Selector function which provides a disabled flash firing mode if available.
  * Otherwise provides `null`.
  */
-fun off(): Iterable<Flash>.() -> Flash? {
-    return single(Flash.Off)
-}
+fun off(): FlashSelector = single(Flash.Off)
 
 /**
  * @return Selector function which provides a forced on flash firing mode if available.
  * Otherwise provides `null`.
  */
-fun on(): Iterable<Flash>.() -> Flash? {
-    return single(Flash.On)
-}
+fun on(): FlashSelector = single(Flash.On)
 
 /**
  * @return Selector function which provides an auto flash firing mode if available.
  * Otherwise provides `null`.
  */
-fun autoFlash(): Iterable<Flash>.() -> Flash? {
-    return single(Flash.Auto)
-}
+fun autoFlash(): FlashSelector = single(Flash.Auto)
 
 /**
  * @return Selector function which provides an auto flash firing mode with red eye
  * reduction if available.
  * Otherwise provides `null`.
  */
-fun autoRedEye(): Iterable<Flash>.() -> Flash? {
-    return single(Flash.AutoRedEye)
-}
+fun autoRedEye(): FlashSelector = single(Flash.AutoRedEye)
 
 /**
  * @return Selector function which provides a torch (continuous on) flash firing mode if
  * available.
  * Otherwise provides `null`.
  */
-fun torch(): Iterable<Flash>.() -> Flash? {
-    return single(Flash.Torch)
-}
+fun torch(): FlashSelector = single(Flash.Torch)

--- a/fotoapparat/src/main/java/io/fotoapparat/selector/FocusModeSelectors.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/selector/FocusModeSelectors.kt
@@ -3,62 +3,50 @@ package io.fotoapparat.selector
 import io.fotoapparat.parameter.FocusMode
 
 
+typealias FocusModeSelector = Iterable<FocusMode>.() -> FocusMode?
+
 /**
  * @return Selector function which provides a non-adjustable focus mode if available.
  * Otherwise provides `null`.
  */
-fun fixed(): Iterable<FocusMode>.() -> FocusMode? {
-    return single(FocusMode.Fixed)
-}
+fun fixed(): FocusModeSelector = single(FocusMode.Fixed)
 
 /**
  * @return Selector function which provides a focus mode targeting infinity if available.
  * Otherwise provides `null`.
  */
-fun infinity(): Iterable<FocusMode>.() -> FocusMode? {
-    return single(FocusMode.Infinity)
-}
+fun infinity(): FocusModeSelector = single(FocusMode.Infinity)
 
 /**
  * @return Selector function which provides a macro focus mode if available.
  * Otherwise provides `null`.
  */
-fun macro(): Iterable<FocusMode>.() -> FocusMode? {
-    return single(FocusMode.Macro)
-}
+fun macro(): FocusModeSelector = single(FocusMode.Macro)
 
 /**
  * @return Selector function which provides an auto focus mode if available.
  * Otherwise provides `null`.
  */
-fun autoFocus(): Iterable<FocusMode>.() -> FocusMode? {
-    return single(FocusMode.Auto)
-}
+fun autoFocus(): FocusModeSelector = single(FocusMode.Auto)
 
 /**
  * @return Selector function which provides a focus mode which constantly tries to stay
  * in focus if available. The speed of focus change is aggressive.
  * Otherwise provides `null`.
  */
-fun continuousFocusPicture(): Iterable<FocusMode>.() -> FocusMode? {
-    return single(FocusMode.ContinuousFocusPicture)
-}
+fun continuousFocusPicture(): FocusModeSelector = single(FocusMode.ContinuousFocusPicture)
 
 /**
  * @return Selector function which provides a focus mode which constantly tries to stay
  * in focus if available. The speed of focus change is smooth.
  * Otherwise provides `null`.
  */
-fun continuousFocusVideo(): Iterable<FocusMode>.() -> FocusMode? {
-    return single(FocusMode.ContinuousFocusVideo)
-}
+fun continuousFocusVideo(): FocusModeSelector = single(FocusMode.ContinuousFocusVideo)
 
 /**
  * @return Selector function which provides a focus mode which will produce images with
  * an extended depth of field if available.
  * Otherwise provides `null`.
  */
-fun edof(): Iterable<FocusMode>.() -> FocusMode? {
-    return single(FocusMode.Edof)
-}
+fun edof(): FocusModeSelector = single(FocusMode.Edof)
 

--- a/fotoapparat/src/main/java/io/fotoapparat/selector/JpegQualitySelectors.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/selector/JpegQualitySelectors.kt
@@ -1,17 +1,19 @@
 package io.fotoapparat.selector
 
+typealias QualitySelector = IntRange.() -> Int?
+
 /**
  * @param quality The specified Jpeq quality value
  * @return Selector function which selects the specified Jpeq quality value.
  */
-fun manualJpegQuality(quality: Int): IntRange.() -> Int? = single(quality)
+fun manualJpegQuality(quality: Int): QualitySelector = single(quality)
 
 /**
  * @return Selector function which always provides the highest quality.
  */
-fun highestQuality(): IntRange.() -> Int? = highest()
+fun highestQuality(): QualitySelector = highest()
 
 /**
  * @return Selector function which always provides the lowest quality.
  */
-fun lowestQuality(): IntRange.() -> Int? = lowest()
+fun lowestQuality(): QualitySelector = lowest()

--- a/fotoapparat/src/main/java/io/fotoapparat/selector/LensPositionSelectors.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/selector/LensPositionSelectors.kt
@@ -3,26 +3,22 @@ package io.fotoapparat.selector
 import io.fotoapparat.characteristic.LensPosition
 
 
+typealias LensPositionSelector = Iterable<LensPosition>.() -> LensPosition?
+
 /**
  * @return Selector function which provides the front camera if it is available.
  * Otherwise provides `null`.
  */
-fun front(): Iterable<LensPosition>.() -> LensPosition? {
-    return single(LensPosition.Front)
-}
+fun front(): LensPositionSelector = single(LensPosition.Front)
 
 /**
  * @return Selector function which provides the back camera if it is available.
  * Otherwise provides `null`.
  */
-fun back(): Iterable<LensPosition>.() -> LensPosition? {
-    return single(LensPosition.Back)
-}
+fun back(): LensPositionSelector = single(LensPosition.Back)
 
 /**
  * @return Selector function which provides the external camera if it is available.
  * Otherwise provides `null`.
  */
-fun external(): Iterable<LensPosition>.() -> LensPosition? {
-    return single(LensPosition.External)
-}
+fun external(): LensPositionSelector = single(LensPosition.External)

--- a/fotoapparat/src/main/java/io/fotoapparat/selector/PreviewFpsRangeSelectors.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/selector/PreviewFpsRangeSelectors.kt
@@ -3,18 +3,18 @@ package io.fotoapparat.selector
 import io.fotoapparat.parameter.FpsRange
 import io.fotoapparat.util.CompareFpsRangeByBounds
 
+typealias FpsRangeSelector = Iterable<FpsRange>.() -> FpsRange?
+
 /**
  * @param fps The specified FPS
  * @return Selector function which selects FPS range that contains the specified FPS.
  * Prefers fixed rates over non fixed ones.
  */
-fun containsFps(fps: Float): Iterable<FpsRange>.() -> FpsRange? = firstAvailable(
+fun containsFps(fps: Float): FpsRangeSelector = firstAvailable(
         exactFixedFps(fps),
         filtered(
                 selector = highestNonFixedFps(),
-                predicate = {
-                    it.contains(fps.toFpsIntRepresentation())
-                }
+                predicate = { range -> fps.toFpsIntRepresentation() in range }
         )
 )
 
@@ -22,18 +22,16 @@ fun containsFps(fps: Float): Iterable<FpsRange>.() -> FpsRange? = firstAvailable
  * @param fps The specified FPS
  * @return Selector function which selects FPS range that contains only the specified FPS.
  */
-fun exactFixedFps(fps: Float): Iterable<FpsRange>.() -> FpsRange? = filtered(
+fun exactFixedFps(fps: Float): FpsRangeSelector = filtered(
         selector = highestFixedFps(),
-        predicate = {
-            it.min == fps.toFpsIntRepresentation()
-        }
+        predicate = { it.min == fps.toFpsIntRepresentation() }
 )
 
 /**
  * @return Selector function which selects FPS range with max FPS.
  * Prefers non fixed rates over fixed ones.
  */
-fun highestFps(): Iterable<FpsRange>.() -> FpsRange? = firstAvailable(
+fun highestFps(): FpsRangeSelector = firstAvailable(
         highestNonFixedFps(),
         highestFixedFps()
 )
@@ -41,7 +39,7 @@ fun highestFps(): Iterable<FpsRange>.() -> FpsRange? = firstAvailable(
 /**
  * @return Selector function which selects FPS range with max FPS and non fixed rate.
  */
-fun highestNonFixedFps(): Iterable<FpsRange>.() -> FpsRange? = filtered(
+fun highestNonFixedFps(): FpsRangeSelector = filtered(
         selector = highestRangeFps(),
         predicate = { !it.isFixed }
 )
@@ -49,7 +47,7 @@ fun highestNonFixedFps(): Iterable<FpsRange>.() -> FpsRange? = filtered(
 /**
  * @return Selector function which selects FPS range with max FPS and fixed rate.
  */
-fun highestFixedFps(): Iterable<FpsRange>.() -> FpsRange? = filtered(
+fun highestFixedFps(): FpsRangeSelector = filtered(
         selector = highestRangeFps(),
         predicate = { it.isFixed }
 )
@@ -58,7 +56,7 @@ fun highestFixedFps(): Iterable<FpsRange>.() -> FpsRange? = filtered(
  * @return Selector function which selects FPS range with min FPS.
  * Prefers non fixed rates over fixed ones.
  */
-fun lowestFps(): Iterable<FpsRange>.() -> FpsRange? = firstAvailable(
+fun lowestFps(): FpsRangeSelector = firstAvailable(
         lowestNonFixedFps(),
         lowestFixedFps()
 )
@@ -66,29 +64,21 @@ fun lowestFps(): Iterable<FpsRange>.() -> FpsRange? = firstAvailable(
 /**
  * @return Selector function which selects FPS range with min FPS and non fixed rate.
  */
-fun lowestNonFixedFps(): Iterable<FpsRange>.() -> FpsRange? {
-    return filtered(
-            selector = lowestRangeFps(),
-            predicate = { !it.isFixed }
-    )
-}
+fun lowestNonFixedFps(): FpsRangeSelector = filtered(
+        selector = lowestRangeFps(),
+        predicate = { !it.isFixed }
+)
 
 /**
  * @return Selector function which selects FPS range with min FPS and fixed rate.
  */
-fun lowestFixedFps(): Iterable<FpsRange>.() -> FpsRange? {
-    return filtered(
-            selector = lowestRangeFps(),
-            predicate = { it.isFixed }
-    )
-}
+fun lowestFixedFps(): FpsRangeSelector = filtered(
+        selector = lowestRangeFps(),
+        predicate = { it.isFixed }
+)
 
-private fun highestRangeFps(): Iterable<FpsRange>.() -> FpsRange? = {
-    maxWith(CompareFpsRangeByBounds)
-}
+private fun highestRangeFps(): FpsRangeSelector = { maxWith(CompareFpsRangeByBounds) }
 
-private fun lowestRangeFps(): Iterable<FpsRange>.() -> FpsRange? = {
-    minWith(CompareFpsRangeByBounds)
-}
+private fun lowestRangeFps(): FpsRangeSelector = { minWith(CompareFpsRangeByBounds) }
 
 private fun Float.toFpsIntRepresentation() = (this * 1000).toInt()

--- a/fotoapparat/src/main/java/io/fotoapparat/selector/ResolutionSelectors.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/selector/ResolutionSelectors.kt
@@ -2,16 +2,14 @@ package io.fotoapparat.selector
 
 import io.fotoapparat.parameter.Resolution
 
+typealias ResolutionSelector = Iterable<Resolution>.() -> Resolution?
+
 /**
  * @return Selector function which always provides the biggest resolution.
  */
-fun highestResolution(): Iterable<Resolution>.() -> Resolution? = {
-    maxBy { it.area }
-}
+fun highestResolution(): ResolutionSelector = { maxBy(Resolution::area) }
 
 /**
  * @return Selector function which always provides the smallest resolution.
  */
-fun lowestResolution(): Iterable<Resolution>.() -> Resolution? = {
-    minBy { it.area }
-}
+fun lowestResolution(): ResolutionSelector = { minBy(Resolution::area) }

--- a/fotoapparat/src/main/java/io/fotoapparat/selector/Selectors.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/selector/Selectors.kt
@@ -20,16 +20,12 @@ fun <T> single(preference: T): Iterable<T>.() -> T? = {
 /**
  * @return Selector function which selects highest [Comparable] value.
  */
-fun <T : Comparable<T>> highest(): Iterable<T>.() -> T? = {
-    max()
-}
+fun <T : Comparable<T>> highest(): Iterable<T>.() -> T? = Iterable<T>::max
 
 /**
  * @return Selector function which selects lowest [Comparable] value.
  */
-fun <T : Comparable<T>> lowest(): Iterable<T>.() -> T? = {
-    min()
-}
+fun <T : Comparable<T>> lowest(): Iterable<T>.() -> T? = Iterable<T>::min
 
 /**
  * @param functions functions in order of importance.

--- a/fotoapparat/src/main/java/io/fotoapparat/selector/SensorSensitivitySelectors.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/selector/SensorSensitivitySelectors.kt
@@ -1,19 +1,21 @@
 package io.fotoapparat.selector
 
 
+typealias SensorSensitivitySelector = Iterable<Int>.() -> Int?
+
 /**
  * @param iso The specified ISO value
  * @return Selector function which selects the specified ISO value. If there
  * is no specified value - selects default or previous ISO value.
  */
-fun manualSensorSensitivity(iso: Int): Iterable<Int>.() -> Int? = single(iso)
+fun manualSensorSensitivity(iso: Int): SensorSensitivitySelector = single(iso)
 
 /**
  * @return Selector function which selects highest ISO value.
  */
-fun highestSensorSensitivity(): Iterable<Int>.() -> Int? = highest()
+fun highestSensorSensitivity(): SensorSensitivitySelector = highest()
 
 /**
  * @return Selector function which selects lowest ISO value.
  */
-fun lowestSensorSensitivity(): Iterable<Int>.() -> Int? = lowest()
+fun lowestSensorSensitivity(): SensorSensitivitySelector = lowest()

--- a/fotoapparat/src/main/java/io/fotoapparat/util/Typealiases.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/util/Typealiases.kt
@@ -1,0 +1,5 @@
+package io.fotoapparat.util
+
+import io.fotoapparat.preview.Frame
+
+typealias FrameProcessor = (Frame) -> Unit

--- a/fotoapparat/src/test/java/io/fotoapparat/FotoapparatBuilderTest.kt
+++ b/fotoapparat/src/test/java/io/fotoapparat/FotoapparatBuilderTest.kt
@@ -3,10 +3,12 @@ package io.fotoapparat
 import android.content.Context
 import android.view.WindowManager
 import io.fotoapparat.characteristic.LensPosition
-import io.fotoapparat.exception.camera.CameraException
+import io.fotoapparat.error.CameraErrorCallback
 import io.fotoapparat.log.Logger
-import io.fotoapparat.parameter.*
-import io.fotoapparat.preview.Frame
+import io.fotoapparat.parameter.Resolution
+import io.fotoapparat.parameter.ScaleType
+import io.fotoapparat.selector.*
+import io.fotoapparat.util.FrameProcessor
 import io.fotoapparat.view.CameraRenderer
 import junit.framework.Assert.*
 import org.junit.Before
@@ -28,27 +30,27 @@ class FotoapparatBuilderTest {
     @Mock
     lateinit var photoResolutionSelector: Iterable<Resolution>.() -> Resolution
     @Mock
-    lateinit var previewResolutionSelector: Iterable<Resolution>.() -> Resolution?
+    lateinit var previewResolutionSelector: ResolutionSelector
     @Mock
     lateinit var lensPositionSelector: Iterable<LensPosition>.() -> LensPosition
     @Mock
-    lateinit var focusModeSelector: Iterable<FocusMode>.() -> FocusMode?
+    lateinit var focusModeSelector: FocusModeSelector
     @Mock
-    lateinit var flashSelector: Iterable<Flash>.() -> Flash?
+    lateinit var flashSelector: FlashSelector
     @Mock
-    lateinit var previewFpsRangeSelector: Iterable<FpsRange>.() -> FpsRange?
+    lateinit var previewFpsRangeSelector: FpsRangeSelector
     @Mock
-    lateinit var sensorSensitivitySelector: Iterable<Int>.() -> Int?
+    lateinit var sensorSensitivitySelector: SensorSensitivitySelector
     @Mock
-    lateinit var jpegQualitySelector: IntRange.() -> Int?
+    lateinit var jpegQualitySelector: QualitySelector
     @Mock
-    lateinit var frameProcessor: (Frame) -> Unit
+    lateinit var frameProcessor: FrameProcessor
 
     @Mock
     lateinit var logger: Logger
 
     @Mock
-    lateinit var cameraErrorCallback: (CameraException) -> Unit
+    lateinit var cameraErrorCallback: CameraErrorCallback
 
     @Before
     fun setUp() {

--- a/fotoapparat/src/test/java/io/fotoapparat/routine/camera/SwitchCameraRoutineTest.kt
+++ b/fotoapparat/src/test/java/io/fotoapparat/routine/camera/SwitchCameraRoutineTest.kt
@@ -1,7 +1,7 @@
 package io.fotoapparat.routine.camera
 
 import io.fotoapparat.characteristic.LensPosition
-import io.fotoapparat.exception.camera.CameraException
+import io.fotoapparat.error.CameraErrorCallback
 import io.fotoapparat.hardware.CameraDevice
 import io.fotoapparat.hardware.Device
 import io.fotoapparat.test.testConfiguration
@@ -26,7 +26,7 @@ internal class SwitchCameraRoutineTest {
     @Mock
     lateinit var cameraRenderer: CameraRenderer
 
-    val mainThreadErrorCallback: (CameraException) -> Unit = {}
+    private val mainThreadErrorCallback: CameraErrorCallback = {}
 
     @Test
     fun `Switch camera, not started`() {
@@ -35,7 +35,7 @@ internal class SwitchCameraRoutineTest {
                 .willThrow(IllegalStateException())
                 .willReturn(oldCameraDevice)
         device.cameraRenderer willReturn cameraRenderer
-        val lensPositionSelector: Collection<LensPosition>.() -> LensPosition.Front = { LensPosition.Front }
+        val lensPositionSelector: Iterable<LensPosition>.() -> LensPosition.Front = { LensPosition.Front }
 
         // When
         device.switchCamera(
@@ -53,7 +53,7 @@ internal class SwitchCameraRoutineTest {
     @Test
     fun `Switch camera, same lens position`() {
         // Given
-        val lensPositionSelector: Collection<LensPosition>.() -> LensPosition.Front = { LensPosition.Front }
+        val lensPositionSelector: Iterable<LensPosition>.() -> LensPosition.Front = { LensPosition.Front }
         device.getLensPositionSelector() willReturn lensPositionSelector
         device.getSelectedCamera() willReturn oldCameraDevice
         device.cameraRenderer willReturn cameraRenderer
@@ -80,7 +80,7 @@ internal class SwitchCameraRoutineTest {
     @Test
     fun `Switch camera, different lens position`() {
         // Given
-        val lensPositionSelector: Collection<LensPosition>.() -> LensPosition.Front = { LensPosition.Front }
+        val lensPositionSelector: Iterable<LensPosition>.() -> LensPosition.Front = { LensPosition.Front }
         device.getLensPositionSelector() willReturn { LensPosition.Back }
         device.getSelectedCamera() willReturn oldCameraDevice
         device.cameraRenderer willReturn cameraRenderer

--- a/fotoapparat/src/test/java/io/fotoapparat/test/TestObjectFactory.kt
+++ b/fotoapparat/src/test/java/io/fotoapparat/test/TestObjectFactory.kt
@@ -6,6 +6,7 @@ import io.fotoapparat.parameter.*
 import io.fotoapparat.parameter.camera.CameraParameters
 import io.fotoapparat.preview.Frame
 import io.fotoapparat.selector.single
+import io.fotoapparat.util.FrameProcessor
 
 /**
  * Test object for [Resolution].
@@ -75,4 +76,4 @@ val testCameraParameters = CameraParameters(
 /**
  * Test frame processor.
  */
-val testFrameProcessor: (Frame) -> Unit = { }
+val testFrameProcessor: FrameProcessor = { }

--- a/sample/src/main/java/io/fotoapparat/sample/MainActivity.kt
+++ b/sample/src/main/java/io/fotoapparat/sample/MainActivity.kt
@@ -8,7 +8,6 @@ import android.widget.CompoundButton
 import android.widget.ImageView
 import android.widget.SeekBar
 import io.fotoapparat.Fotoapparat
-import io.fotoapparat.characteristic.LensPosition
 import io.fotoapparat.configuration.CameraConfiguration
 import io.fotoapparat.configuration.UpdateConfiguration
 import io.fotoapparat.log.logcat
@@ -168,7 +167,7 @@ class MainActivity : AppCompatActivity() {
 private const val LOGGING_TAG = "Fotoapparat Example"
 
 private sealed class Camera(
-        val lensPosition: Collection<LensPosition>.() -> LensPosition?,
+        val lensPosition: LensPositionSelector,
         val configuration: CameraConfiguration
 ) {
 


### PR DESCRIPTION
Hello! Thanks a lot for your library. 

The purpose of this PR is to clean up some parts of codebase according to [Coding Conventions](https://kotlinlang.org/docs/reference/coding-conventions.html)
Also, this PR's brings typealiases for all selectors and some other cases which significantly improve readability.

Here is a short list of general changes:
 - Change builder methods to use `apply()` which allows to omit `return this`
 - Replace all lambdas of selectors with its typealiases, e.g. `FlashSelector`, `QualitySelector`
 - Specify return type explicitly for methods which are exposed. This change allows to not break compatibility of open interface in case of any kind of refactoring.
 - Make some methods to use expression body instead of block one
 - Small changes (use range operator, sort modifiers, convert lamda to reference)

If some changes don't fit your needs feel free to comment what should be changed or reverted.