### PR TITLE
Using only one thread for operating with camera

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/Fotoapparat.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/Fotoapparat.kt
@@ -2,21 +2,17 @@ package io.fotoapparat
 
 import android.content.Context
 import android.support.annotation.FloatRange
-import io.fotoapparat.capability.Capabilities
 import io.fotoapparat.configuration.CameraConfiguration
 import io.fotoapparat.configuration.Configuration
 import io.fotoapparat.error.CameraErrorCallback
 import io.fotoapparat.error.onMainThread
-import io.fotoapparat.exception.camera.CameraException
 import io.fotoapparat.hardware.Device
 import io.fotoapparat.hardware.display.Display
 import io.fotoapparat.hardware.execute
-import io.fotoapparat.hardware.executeTask
 import io.fotoapparat.hardware.orientation.OrientationSensor
 import io.fotoapparat.log.Logger
 import io.fotoapparat.log.none
 import io.fotoapparat.parameter.ScaleType
-import io.fotoapparat.parameter.camera.CameraParameters
 import io.fotoapparat.result.*
 import io.fotoapparat.routine.camera.bootStart
 import io.fotoapparat.routine.camera.shutDown
@@ -30,7 +26,6 @@ import io.fotoapparat.routine.zoom.updateZoomLevel
 import io.fotoapparat.selector.*
 import io.fotoapparat.view.CameraRenderer
 import io.fotoapparat.view.FocalPointSelector
-import java.util.concurrent.FutureTask
 
 /**
  * Camera. Takes pictures.
@@ -113,13 +108,9 @@ class Fotoapparat
     fun takePicture(): PhotoResult {
         logger.recordMethod()
 
-        val takePictureTask = FutureTask<Photo> {
-            device.takePhoto()
-        }
+        val future = execute(device::takePhoto)
 
-        executeTask(takePictureTask)
-
-        return PhotoResult.fromFuture(takePictureTask, logger)
+        return PhotoResult.fromFuture(future, logger)
     }
 
     /**
@@ -130,13 +121,9 @@ class Fotoapparat
     fun getCapabilities(): CapabilitiesResult {
         logger.recordMethod()
 
-        val getCapabilitiesTask = FutureTask<Capabilities> {
-            device.getCapabilities()
-        }
+        val future = execute(device::getCapabilities)
 
-        executeTask(getCapabilitiesTask)
-
-        return PendingResult.fromFuture(getCapabilitiesTask, logger)
+        return PendingResult.fromFuture(future, logger)
     }
 
     /**
@@ -147,13 +134,9 @@ class Fotoapparat
     fun getCurrentParameters(): ParametersResult {
         logger.recordMethod()
 
-        val getCameraParametersTask = FutureTask<CameraParameters> {
-            device.getCurrentParameters()
-        }
+        val future = execute(device::getCurrentParameters)
 
-        executeTask(getCameraParametersTask)
-
-        return PendingResult.fromFuture(getCameraParametersTask, logger)
+        return PendingResult.fromFuture(future, logger)
     }
 
     /**
@@ -202,12 +185,9 @@ class Fotoapparat
     fun focus(): PendingResult<FocusResult> {
         logger.recordMethod()
 
-        val focusTask = FutureTask<FocusResult> {
-            device.focus()
-        }
-        executeTask(focusTask)
+        val future = execute(device::focus)
 
-        return PendingResult.fromFuture(focusTask, logger)
+        return PendingResult.fromFuture(future, logger)
     }
 
     /**

--- a/fotoapparat/src/main/java/io/fotoapparat/Fotoapparat.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/Fotoapparat.kt
@@ -96,6 +96,7 @@ class Fotoapparat
     fun stop() {
         logger.recordMethod()
 
+        executor.cancelTasks()
         executor.execute(Operation {
             device.shutDown(
                     orientationSensor = orientationSensor

--- a/fotoapparat/src/main/java/io/fotoapparat/concurrent/CameraExecutor.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/concurrent/CameraExecutor.kt
@@ -1,0 +1,62 @@
+package io.fotoapparat.concurrent
+
+import java.util.concurrent.*
+
+/**
+ * Executes camera related operations using a dedicated thread and provides a control over the queue
+ * of those operations.
+ *
+ * This class should be accessed only from a one thread at a time.
+ */
+class CameraExecutor(
+        private val executor: ExecutorService = Executors.newSingleThreadExecutor()
+) {
+
+    private val cancellableTasksQueue = LinkedBlockingQueue<Future<*>>()
+
+    /**
+     * Adds operation to the serial execution queue.
+     */
+    fun <T> execute(operation: Operation<T>): Future<T> {
+        val future = executor.submit(Callable {
+            operation.function()
+        })
+
+        if (operation.cancellable) {
+            cancellableTasksQueue += future
+        }
+
+        return future
+    }
+
+    /**
+     * Cancels all cancellable tasks in the queue. Non-cancellable tasks would still be executed.
+     *
+     * After this operation is completed the executor is still in a valid state and can be used
+     * further.
+     */
+    fun cancelTasks() {
+        cancellableTasksQueue.forEach {
+            it.cancel(true)
+        }
+        cancellableTasksQueue.clear()
+    }
+
+    /**
+     * Operation to be executed.
+     */
+    data class Operation<out T>(
+
+            /**
+             * `true` if operation could be cancelled. `false` if operation can not be cancelled.
+             */
+            val cancellable: Boolean = false,
+
+            /**
+             * Body of the operation.
+             */
+            val function: () -> T
+
+    )
+
+}

--- a/fotoapparat/src/main/java/io/fotoapparat/concurrent/CameraExecutor.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/concurrent/CameraExecutor.kt
@@ -1,6 +1,10 @@
 package io.fotoapparat.concurrent
 
-import java.util.concurrent.*
+import java.util.*
+import java.util.concurrent.Callable
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
 
 /**
  * Executes camera related operations using a dedicated thread and provides a control over the queue
@@ -12,7 +16,7 @@ class CameraExecutor(
         private val executor: ExecutorService = Executors.newSingleThreadExecutor()
 ) {
 
-    private val cancellableTasksQueue = LinkedBlockingQueue<Future<*>>()
+    private val cancellableTasksQueue = LinkedList<Future<*>>()
 
     /**
      * Adds operation to the serial execution queue.
@@ -36,9 +40,11 @@ class CameraExecutor(
      * further.
      */
     fun cancelTasks() {
-        cancellableTasksQueue.forEach {
-            it.cancel(true)
-        }
+        cancellableTasksQueue
+                .filter { !it.isDone && !it.isCancelled }
+                .forEach {
+                    it.cancel(true)
+                }
         cancellableTasksQueue.clear()
     }
 

--- a/fotoapparat/src/main/java/io/fotoapparat/concurrent/CameraExecutor.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/concurrent/CameraExecutor.kt
@@ -30,7 +30,15 @@ class CameraExecutor(
             cancellableTasksQueue += future
         }
 
+        cleanUpCancelledTasks()
+
         return future
+    }
+
+    private fun cleanUpCancelledTasks() {
+        cancellableTasksQueue.removeAll {
+            !it.isPending
+        }
     }
 
     /**
@@ -41,12 +49,14 @@ class CameraExecutor(
      */
     fun cancelTasks() {
         cancellableTasksQueue
-                .filter { !it.isDone && !it.isCancelled }
+                .filter { it.isPending }
                 .forEach {
                     it.cancel(true)
                 }
         cancellableTasksQueue.clear()
     }
+
+    private val Future<*>.isPending get() = !isCancelled && !isDone
 
     /**
      * Operation to be executed.

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/CameraDevice.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/CameraDevice.kt
@@ -22,12 +22,11 @@ import io.fotoapparat.parameter.Resolution
 import io.fotoapparat.parameter.camera.CameraParameters
 import io.fotoapparat.parameter.camera.apply.applyNewParameters
 import io.fotoapparat.parameter.camera.convert.toCode
-import io.fotoapparat.preview.Frame
 import io.fotoapparat.preview.PreviewStream
 import io.fotoapparat.result.FocusResult
 import io.fotoapparat.result.Photo
-import io.fotoapparat.util.lineSeparator
 import io.fotoapparat.util.FrameProcessor
+import io.fotoapparat.util.lineSeparator
 import io.fotoapparat.view.Preview
 import kotlinx.coroutines.experimental.CompletableDeferred
 import java.io.IOException

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/Device.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/Device.kt
@@ -4,6 +4,7 @@ package io.fotoapparat.hardware
 
 import android.hardware.Camera
 import io.fotoapparat.characteristic.getCharacteristics
+import io.fotoapparat.concurrent.CameraExecutor
 import io.fotoapparat.configuration.CameraConfiguration
 import io.fotoapparat.configuration.Configuration
 import io.fotoapparat.exception.camera.UnsupportedLensException
@@ -13,7 +14,6 @@ import io.fotoapparat.log.Logger
 import io.fotoapparat.parameter.ScaleType
 import io.fotoapparat.parameter.camera.CameraParameters
 import io.fotoapparat.parameter.camera.provide.getCameraParameters
-import io.fotoapparat.preview.Frame
 import io.fotoapparat.selector.LensPositionSelector
 import io.fotoapparat.util.FrameProcessor
 import io.fotoapparat.view.CameraRenderer
@@ -27,9 +27,10 @@ import kotlinx.coroutines.experimental.CompletableDeferred
 internal open class Device(
         private val logger: Logger,
         private val display: Display,
-        open val scaleType: ScaleType,
-        open val cameraRenderer: CameraRenderer,
-        val focusPointSelector: FocalPointSelector?,
+        internal open val scaleType: ScaleType,
+        internal open val cameraRenderer: CameraRenderer,
+        internal val focusPointSelector: FocalPointSelector?,
+        internal val executor: CameraExecutor,
         numberOfCameras: Int = Camera.getNumberOfCameras(),
         initialConfiguration: CameraConfiguration, initialLensPositionSelector: LensPositionSelector
 ) {

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/Executor.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/Executor.kt
@@ -3,10 +3,8 @@ package io.fotoapparat.hardware
 import android.os.Handler
 import android.os.Looper
 import java.util.concurrent.Executors
+import java.util.concurrent.Future
 
-
-private var taskExecutor = Executors.newSingleThreadExecutor()
-    get() = field.takeUnless { it.isShutdown } ?: Executors.newSingleThreadExecutor().also { field = it }
 
 private val cameraExecutor = Executors.newSingleThreadExecutor()
 private val loggingExecutor = Executors.newSingleThreadExecutor()
@@ -24,18 +22,13 @@ internal val frameProcessingExecutor = Executors.newSingleThreadExecutor()
  * Shuts down all pending camera tasks.
  */
 internal fun shutdownPendingTasks() {
-    taskExecutor.shutdownNow()
+    // FIXME
 }
 
 /**
- * Executes a camera task.
+ * Executes a camera operation and returns a result as a future.
  */
-internal fun executeTask(function: Runnable) = taskExecutor.execute(function)
-
-/**
- * Executes a camera operation.
- */
-internal fun execute(function: () -> Unit) = cameraExecutor.execute(function)
+internal fun <T> execute(function: () -> T): Future<T> = cameraExecutor.submit(function)
 
 /**
  * Executes an operation in the main thread.

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/Executor.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/Executor.kt
@@ -3,12 +3,11 @@ package io.fotoapparat.hardware
 import android.os.Handler
 import android.os.Looper
 import java.util.concurrent.Executors
-import java.util.concurrent.Future
 
 
-private val cameraExecutor = Executors.newSingleThreadExecutor()
 private val loggingExecutor = Executors.newSingleThreadExecutor()
 private val mainThreadHandler = Handler(Looper.getMainLooper())
+
 /**
  * [java.util.concurrent.Executor] operating the [io.fotoapparat.result.PendingResult].
  */
@@ -17,18 +16,6 @@ internal val pendingResultExecutor = Executors.newSingleThreadExecutor()
  * [java.util.concurrent.Executor] operating the [io.fotoapparat.preview.PreviewStream].
  */
 internal val frameProcessingExecutor = Executors.newSingleThreadExecutor()
-
-/**
- * Shuts down all pending camera tasks.
- */
-internal fun shutdownPendingTasks() {
-    // FIXME
-}
-
-/**
- * Executes a camera operation and returns a result as a future.
- */
-internal fun <T> execute(function: () -> T): Future<T> = cameraExecutor.submit(function)
 
 /**
  * Executes an operation in the main thread.

--- a/fotoapparat/src/main/java/io/fotoapparat/result/PendingResult.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/result/PendingResult.kt
@@ -6,10 +6,7 @@ import io.fotoapparat.hardware.executeMainThread
 import io.fotoapparat.hardware.pendingResultExecutor
 import io.fotoapparat.log.Logger
 import io.fotoapparat.parameter.camera.CameraParameters
-import java.util.concurrent.ExecutionException
-import java.util.concurrent.Executor
-import java.util.concurrent.Future
-import java.util.concurrent.FutureTask
+import java.util.concurrent.*
 
 
 /**
@@ -77,6 +74,8 @@ internal constructor(
                 logger.log("Couldn't decode bitmap from byte array")
             } catch (e: InterruptedException) {
                 logger.log("Couldn't deliver pending result: Camera stopped before delivering result.")
+            } catch (e: CancellationException) {
+                logger.log("Couldn't deliver pending result: Camera operation was cancelled.")
             } catch (e: ExecutionException) {
                 logger.log("Couldn't deliver pending result: Operation failed internally.")
                 callback(null)

--- a/fotoapparat/src/main/java/io/fotoapparat/routine/camera/StartRoutine.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/routine/camera/StartRoutine.kt
@@ -1,9 +1,9 @@
 package io.fotoapparat.routine.camera
 
+import io.fotoapparat.concurrent.CameraExecutor.Operation
 import io.fotoapparat.error.CameraErrorCallback
 import io.fotoapparat.exception.camera.CameraException
 import io.fotoapparat.hardware.Device
-import io.fotoapparat.hardware.execute
 import io.fotoapparat.hardware.orientation.Orientation
 import io.fotoapparat.hardware.orientation.OrientationSensor
 import io.fotoapparat.hardware.orientation.OrientationState
@@ -64,9 +64,9 @@ internal fun Device.start() {
     }
 
     focusPointSelector?.setFocalPointListener { focalRequest ->
-        execute {
+        executor.execute(Operation(cancellable = true) {
             focusOnPoint(focalRequest)
-        }
+        })
     }
 
     cameraDevice.run {

--- a/fotoapparat/src/main/java/io/fotoapparat/routine/camera/StartRoutine.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/routine/camera/StartRoutine.kt
@@ -3,8 +3,8 @@ package io.fotoapparat.routine.camera
 import io.fotoapparat.error.CameraErrorCallback
 import io.fotoapparat.exception.camera.CameraException
 import io.fotoapparat.hardware.Device
-import io.fotoapparat.hardware.executeTask
-import io.fotoapparat.hardware.orientation.Orientation.Vertical.Portrait
+import io.fotoapparat.hardware.execute
+import io.fotoapparat.hardware.orientation.Orientation
 import io.fotoapparat.hardware.orientation.OrientationSensor
 import io.fotoapparat.hardware.orientation.OrientationState
 import io.fotoapparat.routine.focus.focusOnPoint
@@ -45,7 +45,7 @@ internal fun Device.start() {
         )
         setDisplayOrientation(
                 orientationState = OrientationState(
-                        deviceOrientation = Portrait,
+                        deviceOrientation = Orientation.Vertical.Portrait,
                         screenOrientation = getScreenOrientation()
                 )
         )
@@ -64,9 +64,9 @@ internal fun Device.start() {
     }
 
     focusPointSelector?.setFocalPointListener { focalRequest ->
-        executeTask(Runnable {
+        execute {
             focusOnPoint(focalRequest)
-        })
+        }
     }
 
     cameraDevice.run {

--- a/fotoapparat/src/main/java/io/fotoapparat/routine/camera/StopRoutine.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/routine/camera/StopRoutine.kt
@@ -3,7 +3,6 @@ package io.fotoapparat.routine.camera
 import io.fotoapparat.hardware.CameraDevice
 import io.fotoapparat.hardware.Device
 import io.fotoapparat.hardware.orientation.OrientationSensor
-import io.fotoapparat.hardware.shutdownPendingTasks
 import io.fotoapparat.routine.orientation.stopMonitoring
 
 
@@ -14,7 +13,7 @@ internal fun Device.shutDown(
         orientationSensor: OrientationSensor
 ) {
 
-    shutdownPendingTasks()
+    executor.cancelTasks()
 
     orientationSensor.stopMonitoring()
 

--- a/fotoapparat/src/main/java/io/fotoapparat/routine/camera/StopRoutine.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/routine/camera/StopRoutine.kt
@@ -12,9 +12,6 @@ import io.fotoapparat.routine.orientation.stopMonitoring
 internal fun Device.shutDown(
         orientationSensor: OrientationSensor
 ) {
-
-    executor.cancelTasks()
-
     orientationSensor.stopMonitoring()
 
     val cameraDevice = getSelectedCamera()

--- a/fotoapparat/src/main/java/io/fotoapparat/routine/orientation/StartOrientationRoutine.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/routine/orientation/StartOrientationRoutine.kt
@@ -1,7 +1,7 @@
 package io.fotoapparat.routine.orientation
 
+import io.fotoapparat.concurrent.CameraExecutor.Operation
 import io.fotoapparat.hardware.Device
-import io.fotoapparat.hardware.execute
 import io.fotoapparat.hardware.orientation.OrientationSensor
 import io.fotoapparat.hardware.orientation.OrientationState
 
@@ -12,9 +12,9 @@ internal fun Device.startOrientationMonitoring(
         orientationSensor: OrientationSensor
 ) {
     orientationSensor.start { orientationState: OrientationState ->
-        execute {
+        executor.execute(Operation(cancellable = true) {
             val cameraDevice = getSelectedCamera()
             cameraDevice.setDisplayOrientation(orientationState)
-        }
+        })
     }
 }


### PR DESCRIPTION
We now differentiate between cancelable (take a picture, focus, etc.) and non-cancelable operations (start camera, stop camera).

Upon stopping the Fotoapparat instance we make sure that all cancelable operations are canceled.