### PR TITLE
Support exposure compensation

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/FotoapparatBuilder.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/FotoapparatBuilder.kt
@@ -107,6 +107,15 @@ class FotoapparatBuilder internal constructor(private var context: Context) {
     }
 
     /**
+     * @param selector selects exposure compensation value from available range.
+     */
+    fun exposureCompensation(selector: ExposureSelector): FotoapparatBuilder = apply {
+        configuration = configuration.copy(
+                exposureCompensation = selector
+        )
+    }
+
+    /**
      * @param frameProcessor receives preview frames for processing.
      * @see FrameProcessorJava
      */

--- a/fotoapparat/src/main/java/io/fotoapparat/capability/Capabilities.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/capability/Capabilities.kt
@@ -17,6 +17,7 @@ data class Capabilities(
         val maxFocusAreas: Int,
         val maxMeteringAreas: Int,
         val jpegQualityRange: IntRange,
+        val exposureCompensationRange: IntRange,
         val previewFpsRanges: Set<FpsRange>,
         val antiBandingModes: Set<AntiBandingMode>,
         val pictureResolutions: Set<Resolution>,
@@ -42,6 +43,7 @@ data class Capabilities(
                 "maxFocusAreas:" + maxFocusAreas.wrap() +
                 "maxMeteringAreas:" + maxMeteringAreas.wrap() +
                 "jpegQualityRange:" + jpegQualityRange.wrap() +
+                "exposureCompensationRange:" + exposureCompensationRange.wrap() +
                 "antiBandingModes:" + antiBandingModes.wrap() +
                 "previewFpsRanges:" + previewFpsRanges.wrap() +
                 "pictureResolutions:" + pictureResolutions.wrap() +

--- a/fotoapparat/src/main/java/io/fotoapparat/capability/provide/CapabilitiesProvider.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/capability/provide/CapabilitiesProvider.kt
@@ -21,6 +21,7 @@ private fun SupportedParameters.getCapabilities(): Capabilities {
             canSmoothZoom = supportedSmoothZoom,
             maxMeteringAreas = maxNumMeteringAreas,
             jpegQualityRange = jpegQualityRange,
+            exposureCompensationRange = exposureCompensationRange,
             antiBandingModes = supportedAutoBandingModes.extract(String::toAntiBandingMode),
             sensorSensitivities = sensorSensitivities.toSet(),
             previewFpsRanges = supportedPreviewFpsRanges.extract { it.toFpsRange() },

--- a/fotoapparat/src/main/java/io/fotoapparat/configuration/CameraConfiguration.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/configuration/CameraConfiguration.kt
@@ -6,6 +6,7 @@ import io.fotoapparat.preview.FrameProcessor as FrameProcessorJava
 
 
 private const val DEFAULT_JPEG_QUALITY = 90
+private const val DEFAULT_EXPOSURE_COMPENSATION = 0
 
 /**
  * A camera configuration which has all it's selectors defined.
@@ -19,6 +20,7 @@ data class CameraConfiguration(
                 infinity()
         ),
         override val jpegQuality: QualitySelector = manualJpegQuality(DEFAULT_JPEG_QUALITY),
+        override val exposureCompensation: ExposureSelector = manualExposure(DEFAULT_EXPOSURE_COMPENSATION),
         override val frameProcessor: FrameProcessor = {},
         override val previewFpsRange: FpsRangeSelector = highestFps(),
         override val antiBandingMode: AntiBandingModeSelector = firstAvailable(
@@ -57,9 +59,9 @@ data class CameraConfiguration(
             )
         }
 
-        fun sensorSensitivity(selector: SensorSensitivitySelector): Builder = apply {
+        fun exposureCompensation(selector: ExposureSelector): Builder = apply {
             cameraConfiguration = cameraConfiguration.copy(
-                    sensorSensitivity = selector
+                    exposureCompensation = selector
             )
         }
 
@@ -72,6 +74,12 @@ data class CameraConfiguration(
         fun jpegQuality(selector: QualitySelector): Builder = apply {
             cameraConfiguration.copy(
                     jpegQuality = selector
+            )
+        }
+
+        fun sensorSensitivity(selector: SensorSensitivitySelector): Builder = apply {
+            cameraConfiguration = cameraConfiguration.copy(
+                    sensorSensitivity = selector
             )
         }
 

--- a/fotoapparat/src/main/java/io/fotoapparat/configuration/Configuration.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/configuration/Configuration.kt
@@ -7,6 +7,7 @@ interface Configuration {
     val flashMode: FlashSelector?
     val focusMode: FocusModeSelector?
     val jpegQuality: QualitySelector?
+    val exposureCompensation: ExposureSelector?
     val frameProcessor: FrameProcessor?
     val previewFpsRange: FpsRangeSelector?
     val antiBandingMode: AntiBandingModeSelector?

--- a/fotoapparat/src/main/java/io/fotoapparat/configuration/UpdateConfiguration.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/configuration/UpdateConfiguration.kt
@@ -10,6 +10,7 @@ data class UpdateConfiguration(
         override val flashMode: FlashSelector? = null,
         override val focusMode: FocusModeSelector? = null,
         override val jpegQuality: QualitySelector? = null,
+        override val exposureCompensation: ExposureSelector? = null,
         override val frameProcessor: FrameProcessor? = null,
         override val previewFpsRange: FpsRangeSelector? = null,
         override val antiBandingMode: AntiBandingModeSelector? = null,
@@ -58,6 +59,12 @@ data class UpdateConfiguration(
         fun jpegQuality(selector: QualitySelector): Builder = apply {
             configuration = configuration.copy(
                     jpegQuality = selector
+            )
+        }
+
+        fun exposureCompensation(selector: ExposureSelector): Builder = apply {
+            configuration = configuration.copy(
+                    exposureCompensation = selector
             )
         }
 

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/Device.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/Device.kt
@@ -167,6 +167,7 @@ internal fun updateConfiguration(
 ) = CameraConfiguration(
         flashMode = newConfiguration.flashMode ?: savedConfiguration.flashMode,
         focusMode = newConfiguration.focusMode ?: savedConfiguration.focusMode,
+        exposureCompensation = newConfiguration.exposureCompensation ?: savedConfiguration.exposureCompensation,
         frameProcessor = newConfiguration.frameProcessor ?: savedConfiguration.frameProcessor,
         previewFpsRange = newConfiguration.previewFpsRange ?: savedConfiguration.previewFpsRange,
         sensorSensitivity = newConfiguration.sensorSensitivity

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/SupportedParameters.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/SupportedParameters.kt
@@ -84,6 +84,13 @@ internal class SupportedParameters(
     }
 
     /**
+     * @return A [IntRange] of exposure compensation values supported by the camera.
+     */
+    val exposureCompensationRange by lazy {
+        IntRange(cameraParameters.minExposureCompensation, cameraParameters.maxExposureCompensation)
+    }
+
+    /**
      * @see Camera.Parameters.getMaxNumFocusAreas
      */
     val maxNumFocusAreas by lazy {

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/camera/CameraParameters.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/camera/CameraParameters.kt
@@ -13,6 +13,7 @@ data class CameraParameters(
         val flashMode: Flash,
         val focusMode: FocusMode,
         val jpegQuality: Int,
+        val exposureCompensation: Int,
         val previewFpsRange: FpsRange,
         val antiBandingMode: AntiBandingMode,
         val sensorSensitivity: Int?,
@@ -24,6 +25,7 @@ data class CameraParameters(
                 "flashMode:" + flashMode.wrap() +
                 "focusMode:" + focusMode.wrap() +
                 "jpegQuality:" + jpegQuality.wrap() +
+                "exposureCompensation:" + exposureCompensation.wrap() +
                 "previewFpsRange:" + previewFpsRange.wrap() +
                 "antiBandingMode:" + antiBandingMode.wrap() +
                 "sensorSensitivity:" + sensorSensitivity.wrap() +

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/camera/apply/CameraParametersApplicator.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/camera/apply/CameraParametersApplicator.kt
@@ -24,7 +24,7 @@ internal fun Camera.Parameters.applyNewParameters(newParameters: CameraParameter
 private infix fun CameraParameters.tryApplyInto(parameters: Camera.Parameters) {
     flashMode applyInto parameters
     focusMode applyInto parameters
-    jpegQuality applyInto parameters
+    jpegQuality applyJpegQualityInto parameters
     exposureCompensation applyExposureCompensationInto parameters
     antiBandingMode applyInto parameters
     previewFpsRange applyInto parameters
@@ -41,7 +41,7 @@ private infix fun FocusMode.applyInto(parameters: Camera.Parameters) {
     parameters.focusMode = toCode()
 }
 
-private infix fun Int.applyInto(parameters: Camera.Parameters) {
+private infix fun Int.applyJpegQualityInto(parameters: Camera.Parameters) {
     parameters.jpegQuality = this
 }
 

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/camera/apply/CameraParametersApplicator.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/camera/apply/CameraParametersApplicator.kt
@@ -25,6 +25,7 @@ private infix fun CameraParameters.tryApplyInto(parameters: Camera.Parameters) {
     flashMode applyInto parameters
     focusMode applyInto parameters
     jpegQuality applyInto parameters
+    exposureCompensation applyExposureCompensationInto parameters
     antiBandingMode applyInto parameters
     previewFpsRange applyInto parameters
     previewResolution applyPreviewInto parameters
@@ -42,6 +43,10 @@ private infix fun FocusMode.applyInto(parameters: Camera.Parameters) {
 
 private infix fun Int.applyInto(parameters: Camera.Parameters) {
     parameters.jpegQuality = this
+}
+
+private infix fun Int.applyExposureCompensationInto(parameters: Camera.Parameters) {
+    parameters.exposureCompensation = this
 }
 
 private infix fun AntiBandingMode.applyInto(parameters: Camera.Parameters) {

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/camera/provide/CameraParametersProvider.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/camera/provide/CameraParametersProvider.kt
@@ -32,6 +32,7 @@ internal fun getCameraParameters(
                     flashMode = flashMode selectFrom flashModes,
                     focusMode = focusMode selectFrom focusModes,
                     jpegQuality = jpegQuality selectFrom jpegQualityRange,
+                    exposureCompensation = exposureCompensation selectFrom exposureCompensationRange,
                     previewFpsRange = previewFpsRange selectFrom previewFpsRanges,
                     antiBandingMode = antiBandingMode selectFrom antiBandingModes,
                     pictureResolution = selectedPictureResolution,

--- a/fotoapparat/src/main/java/io/fotoapparat/selector/ExposureCompensationSelectors.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/selector/ExposureCompensationSelectors.kt
@@ -21,4 +21,4 @@ fun lowestExposure(): ExposureSelector = lowest()
 /**
  * @return Selector function which always provides the default exposure.
  */
-fun autoExposure(): ExposureSelector = single(0)
+fun defaultExposure(): ExposureSelector = single(0)

--- a/fotoapparat/src/main/java/io/fotoapparat/selector/ExposureCompensationSelectors.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/selector/ExposureCompensationSelectors.kt
@@ -1,0 +1,24 @@
+package io.fotoapparat.selector
+
+typealias ExposureSelector = IntRange.() -> Int?
+
+/**
+ * @param exposure The specified exposure compensation value
+ * @return Selector function which selects the specified exposure compensation value.
+ */
+fun manualExposure(exposure: Int): ExposureSelector = single(exposure)
+
+/**
+ * @return Selector function which always provides the highest exposure.
+ */
+fun highestExposure(): ExposureSelector = highest()
+
+/**
+ * @return Selector function which always provides the lowest exposure.
+ */
+fun lowestExposure(): ExposureSelector = lowest()
+
+/**
+ * @return Selector function which always provides the default exposure.
+ */
+fun autoExposure(): ExposureSelector = single(0)

--- a/fotoapparat/src/test/java/io/fotoapparat/parameter/camera/provide/CameraParametersProviderTest.kt
+++ b/fotoapparat/src/test/java/io/fotoapparat/parameter/camera/provide/CameraParametersProviderTest.kt
@@ -17,6 +17,7 @@ internal class CameraParametersProviderTest {
     val resolution = Resolution(10, 10)
     val fpsRange = FpsRange(20000, 20000)
     val jpegQuality = 80
+    val exposureCompensation = 5
     val iso = 100
 
     val capabilities = Capabilities(
@@ -29,6 +30,7 @@ internal class CameraParametersProviderTest {
             previewFpsRanges = setOf(fpsRange),
             antiBandingModes = setOf(AntiBandingMode.None),
             jpegQualityRange = IntRange(0, 100),
+            exposureCompensationRange = IntRange(-20, 20),
             pictureResolutions = setOf(resolution),
             previewResolutions = setOf(resolution),
             sensorSensitivities = setOf(iso)
@@ -38,6 +40,7 @@ internal class CameraParametersProviderTest {
             flashMode = single(Flash.AutoRedEye),
             focusMode = single(FocusMode.Fixed),
             jpegQuality = single(jpegQuality),
+            exposureCompensation = single(exposureCompensation),
             frameProcessor = {},
             antiBandingMode = single(AntiBandingMode.None),
             previewFpsRange = single(fpsRange),
@@ -62,6 +65,7 @@ internal class CameraParametersProviderTest {
                         flashMode = Flash.AutoRedEye,
                         focusMode = FocusMode.Fixed,
                         jpegQuality = jpegQuality,
+                        exposureCompensation = exposureCompensation,
                         previewFpsRange = fpsRange,
                         antiBandingMode = AntiBandingMode.None,
                         pictureResolution = resolution,
@@ -159,6 +163,23 @@ internal class CameraParametersProviderTest {
         // Given
         val definedConfiguration = definedConfiguration.copy(
                 jpegQuality = nothing()
+        )
+
+        // When
+        getCameraParameters(
+                capabilities = capabilities,
+                cameraConfiguration = definedConfiguration
+        )
+
+        // Then
+        // throw exception
+    }
+
+    @Test(expected = UnsupportedConfigurationException::class)
+    fun `Select no exposure compensation`() {
+        // Given
+        val definedConfiguration = definedConfiguration.copy(
+                exposureCompensation = nothing()
         )
 
         // When
@@ -313,6 +334,26 @@ internal class CameraParametersProviderTest {
         )
         val definedConfiguration = definedConfiguration.copy(
                 jpegQuality = { 200 }
+        )
+
+        // When
+        getCameraParameters(
+                capabilities = capabilities,
+                cameraConfiguration = definedConfiguration
+        )
+
+        // Then
+        // throw exception
+    }
+
+    @Test(expected = InvalidConfigurationException::class)
+    fun `Select exposure compensation which is not supported`() {
+        // Given
+        val capabilities = capabilities.copy(
+                exposureCompensationRange = IntRange(-20, 20)
+        )
+        val definedConfiguration = definedConfiguration.copy(
+                exposureCompensation = { 100 }
         )
 
         // When

--- a/fotoapparat/src/test/java/io/fotoapparat/test/TestObjectFactory.kt
+++ b/fotoapparat/src/test/java/io/fotoapparat/test/TestObjectFactory.kt
@@ -29,6 +29,11 @@ val testIso = 100
 val jpegQuality = 80
 
 /**
+ * Test object for camera exposure compensation.
+ */
+val exposureCompensation = 5
+
+/**
  * Test object for [CameraConfiguration].
  */
 internal val testConfiguration = CameraConfiguration(
@@ -52,6 +57,7 @@ val testCapabilities = Capabilities(
         maxFocusAreas = 100,
         maxMeteringAreas = 100,
         jpegQualityRange = IntRange(0, 100),
+        exposureCompensationRange = IntRange(-20, 20),
         antiBandingModes = setOf(AntiBandingMode.None),
         previewFpsRanges = setOf(testFpsRange),
         pictureResolutions = setOf(testResolution),
@@ -66,6 +72,7 @@ val testCameraParameters = CameraParameters(
         flashMode = Flash.AutoRedEye,
         focusMode = FocusMode.Fixed,
         jpegQuality = jpegQuality,
+        exposureCompensation = exposureCompensation,
         antiBandingMode = AntiBandingMode.None,
         previewFpsRange = testFpsRange,
         sensorSensitivity = testIso,


### PR DESCRIPTION
Hopefully this is more helpful than it is trouble. I am not entirely sure about my unit tests. 

Since different devices will return a different IntRange for exposure compensation, I figured the best way to implement it would be with the typical highest, lowest and manual selectors.

In addition to those selectors I added an autoExposure selector which returns the exposure compensation back to the default zero. It isn’t strictly necessary since one could set it manually to zero themselves. I can remove it if you see fit.

