### PR TITLE
Invalidate cachedZoomParameters when updating configuration

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/CameraDevice.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/CameraDevice.kt
@@ -306,6 +306,10 @@ internal open class CameraDevice(
                     camera.parameters = it
                 }
     }
+        
+    open fun clearCachedZoomParameters() {
+        cachedZoomParameters = null
+    }
 
     private fun Camera.focusSafely(): FocusResult {
         val latch = CountDownLatch(1)

--- a/fotoapparat/src/main/java/io/fotoapparat/routine/camera/UpdateConfigurationRoutine.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/routine/camera/UpdateConfigurationRoutine.kt
@@ -33,4 +33,6 @@ internal fun Device.updateCameraConfiguration(
     cameraDevice.updateFrameProcessor(
             frameProcessor = frameProcessor
     )
+    
+    cameraDevice.clearCachedZoomParameters()
 }


### PR DESCRIPTION
The cachedZoomParameters don't get invalidated when updating the configuration. That's why running this code:

```
fotoapparat.updateConfiguration(UpdateConfiguration(flashMode = torch()))
fotoapparat.setZoom(0.5f)
```

results in the torch being off. By clearing the cachedZoomParameters when calling `updateConfiguration()`, this piece of code results in the torch turned on (as intended).