### PR TITLE
Add setOneShotPreviewCallback to get single preview frame

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/Fotoapparat.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/Fotoapparat.kt
@@ -1,6 +1,7 @@
 package io.fotoapparat
 
 import android.content.Context
+import android.hardware.Camera
 import android.support.annotation.FloatRange
 import io.fotoapparat.concurrent.CameraExecutor
 import io.fotoapparat.concurrent.CameraExecutor.Operation
@@ -15,14 +16,12 @@ import io.fotoapparat.log.Logger
 import io.fotoapparat.log.none
 import io.fotoapparat.parameter.ScaleType
 import io.fotoapparat.result.*
-import io.fotoapparat.routine.camera.bootStart
-import io.fotoapparat.routine.camera.shutDown
-import io.fotoapparat.routine.camera.switchCamera
-import io.fotoapparat.routine.camera.updateDeviceConfiguration
+import io.fotoapparat.routine.camera.*
 import io.fotoapparat.routine.capability.getCapabilities
 import io.fotoapparat.routine.focus.focus
 import io.fotoapparat.routine.parameter.getCurrentParameters
 import io.fotoapparat.routine.photo.takePhoto
+import io.fotoapparat.routine.preview.setOneshotPreviewCallback
 import io.fotoapparat.routine.zoom.updateZoomLevel
 import io.fotoapparat.selector.*
 import io.fotoapparat.view.CameraRenderer
@@ -206,6 +205,13 @@ class Fotoapparat
         ))
 
         return PendingResult.fromFuture(future, logger)
+    }
+
+    /**
+     * Sets one shot preview callback - to get single frame from preview stream
+     */
+    fun setOneshotPreviewCallback(callback: Camera.PreviewCallback) {
+        device.setOneshotPreviewCallback(callback)
     }
 
     /**

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/CameraDevice.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/CameraDevice.kt
@@ -1,4 +1,3 @@
-@file:Suppress("DEPRECATION")
 
 package io.fotoapparat.hardware
 
@@ -179,6 +178,15 @@ internal open class CameraDevice(
         logger.recordMethod()
 
         previewStream.updateProcessorSafely(frameProcessor)
+    }
+
+    /**
+     * Sets one shot preview callback - to get single frame from preview stream
+     */
+    fun setOneShotPreviewCallback(callback: Camera.PreviewCallback){
+        logger.recordMethod()
+
+        camera.setOneShotPreviewCallback(callback)
     }
 
     /**

--- a/fotoapparat/src/main/java/io/fotoapparat/routine/preview/OneShotPreviewRoutine.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/routine/preview/OneShotPreviewRoutine.kt
@@ -1,0 +1,15 @@
+package io.fotoapparat.routine.preview
+
+import android.hardware.Camera
+import io.fotoapparat.hardware.Device
+import kotlinx.coroutines.experimental.runBlocking
+
+/**
+ * Sets one shot preview callback - to get single frame from preview stream
+ */
+internal fun Device.setOneshotPreviewCallback(callback: Camera.PreviewCallback) = runBlocking {
+    val camera = awaitSelectedCamera()
+    camera.setOneShotPreviewCallback(callback)
+}
+
+


### PR DESCRIPTION
This adds setOneShotPreviewCallback to get single frame from preview. It is different fro$
1) It only returns one frame and removes callback after
2) It produces frame that has no tearing, unlike the ones from frame processor where move$

Im not sure whether it belongs in another routine or if the runBlocking is needed at all.
I quickly did it like focusRoutine and it works for me, feedback is welcome.

Issue: https://github.com/Fotoapparat/Fotoapparat/issues/200