### PR TITLE
Added focus view to Java example activity

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/FotoapparatBuilder.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/FotoapparatBuilder.kt
@@ -11,6 +11,7 @@ import io.fotoapparat.selector.*
 import io.fotoapparat.util.FrameProcessor
 import io.fotoapparat.view.CameraRenderer
 import io.fotoapparat.view.CameraView
+import io.fotoapparat.view.FocusView
 import io.fotoapparat.preview.FrameProcessor as FrameProcessorJava
 
 /**
@@ -25,6 +26,7 @@ class FotoapparatBuilder internal constructor(private var context: Context) {
     )
     internal var cameraErrorCallback: CameraErrorCallback = {}
     internal var renderer: CameraRenderer? = null
+    internal var focusView: FocusView? = null
     internal var scaleType: ScaleType = ScaleType.CenterCrop
     internal var logger: Logger = none()
 
@@ -164,6 +166,13 @@ class FotoapparatBuilder internal constructor(private var context: Context) {
             apply { this.renderer = renderer }
 
     /**
+     * @param focusView view which will be used for touch to focus.
+     * @see FocusView
+     */
+    fun focusView(focusView: FocusView): FotoapparatBuilder =
+            apply { this.focusView = focusView }
+
+    /**
      * @return set up instance of [Fotoapparat].
      * @throws IllegalStateException if some mandatory parameters are not specified.
      */
@@ -181,6 +190,7 @@ class FotoapparatBuilder internal constructor(private var context: Context) {
         return Fotoapparat(
                 context = context,
                 view = renderer,
+                focusView = focusView,
                 lensPosition = lensPositionSelector,
                 cameraConfiguration = configuration,
                 scaleType = scaleType,

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+        <!--Set android:name to ".ActivityJava" for java example-->
         <activity
             android:name=".MainActivity"
             android:screenOrientation="fullSensor">

--- a/sample/src/main/java/io/fotoapparat/sample/ActivityJava.java
+++ b/sample/src/main/java/io/fotoapparat/sample/ActivityJava.java
@@ -122,7 +122,7 @@ public class ActivityJava extends AppCompatActivity {
                 ))
                 .cameraErrorCallback(new CameraErrorListener() {
                     @Override
-                    public void onError(CameraException e) {
+                    public void onError(@NotNull CameraException e) {
                         Toast.makeText(ActivityJava.this, e.toString(), Toast.LENGTH_LONG).show();
                     }
                 })


### PR DESCRIPTION
I see getting the `FocusView` to work with the `CameraView` you need to pass its reference in to the Fotoapparat constructor.  (I was actually expecting to set the FilterView through the Fotoapparat builder).

Here is an updated Java activity that uses the new constructor.