### PR TITLE
Add "max zoom" value into camera capabilities.

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/capability/Capabilities.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/capability/Capabilities.kt
@@ -10,8 +10,7 @@ import io.fotoapparat.util.wrap
  * Sensor sensitivities is not guaranteed to always contain a value.
  */
 data class Capabilities(
-        val canZoom: Boolean,
-        val maxZoom: Int,
+        val zoom: Zoom,
         val flashModes: Set<Flash>,
         val focusModes: Set<FocusMode>,
         val canSmoothZoom: Boolean,
@@ -37,8 +36,7 @@ data class Capabilities(
 
     override fun toString(): String {
         return "Capabilities" + lineSeparator +
-                "canZoom:" + canZoom.wrap() +
-                "maxZoom:" + maxZoom.wrap() +
+                "zoom:" + zoom.wrap() +
                 "flashModes:" + flashModes.wrap() +
                 "focusModes:" + focusModes.wrap() +
                 "canSmoothZoom:" + canSmoothZoom.wrap() +

--- a/fotoapparat/src/main/java/io/fotoapparat/capability/Capabilities.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/capability/Capabilities.kt
@@ -11,6 +11,7 @@ import io.fotoapparat.util.wrap
  */
 data class Capabilities(
         val canZoom: Boolean,
+        val maxZoom: Int,
         val flashModes: Set<Flash>,
         val focusModes: Set<FocusMode>,
         val canSmoothZoom: Boolean,
@@ -37,6 +38,7 @@ data class Capabilities(
     override fun toString(): String {
         return "Capabilities" + lineSeparator +
                 "canZoom:" + canZoom.wrap() +
+                "maxZoom:" + maxZoom.wrap() +
                 "flashModes:" + flashModes.wrap() +
                 "focusModes:" + focusModes.wrap() +
                 "canSmoothZoom:" + canSmoothZoom.wrap() +

--- a/fotoapparat/src/main/java/io/fotoapparat/capability/provide/CapabilitiesProvider.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/capability/provide/CapabilitiesProvider.kt
@@ -14,8 +14,7 @@ internal fun Camera.getCapabilities() = SupportedParameters(parameters).getCapab
 
 private fun SupportedParameters.getCapabilities(): Capabilities {
     return Capabilities(
-            canZoom = supportedZoom,
-            maxZoom = maxSupportedZoom,
+            zoom = supportedZoom,
             flashModes = flashModes.extract { it.toFlash() },
             focusModes = focusModes.extract { it.toFocusMode() },
             maxFocusAreas = maxNumFocusAreas,

--- a/fotoapparat/src/main/java/io/fotoapparat/capability/provide/CapabilitiesProvider.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/capability/provide/CapabilitiesProvider.kt
@@ -15,6 +15,7 @@ internal fun Camera.getCapabilities() = SupportedParameters(parameters).getCapab
 private fun SupportedParameters.getCapabilities(): Capabilities {
     return Capabilities(
             canZoom = supportedZoom,
+            maxZoom = maxSupportedZoom,
             flashModes = flashModes.extract { it.toFlash() },
             focusModes = focusModes.extract { it.toFocusMode() },
             maxFocusAreas = maxNumFocusAreas,

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/SupportedParameters.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/SupportedParameters.kt
@@ -60,7 +60,7 @@ internal class SupportedParameters(
      * and [io.fotoapparat.parameter.Zoom.VariableZoom] with max zoom level otherwise.
      */
     val supportedZoom by lazy {
-        if (cameraParameters.isZoomSupported) Zoom.VariableZoom(0, cameraParameters.maxZoom) else Zoom.FixedZoom
+        if (cameraParameters.isZoomSupported) Zoom.VariableZoom(cameraParameters.maxZoom) else Zoom.FixedZoom
     }
 
     /**

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/SupportedParameters.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/SupportedParameters.kt
@@ -56,17 +56,11 @@ internal class SupportedParameters(
     }
 
     /**
-     * @see Camera.Parameters.getMaxZoom
-     */
-    val maxSupportedZoom by lazy {
-        cameraParameters.maxZoom
-    }
-
-    /**
-     * @see Camera.Parameters.isZoomSupported
+     * @return [io.fotoapparat.parameter.Zoom.FixedZoom] if [Camera.Parameters.isZoomSupported] returns false,
+     * and [io.fotoapparat.parameter.Zoom.VariableZoom] with max zoom level otherwise.
      */
     val supportedZoom by lazy {
-        cameraParameters.isZoomSupported
+        if (cameraParameters.isZoomSupported) Zoom.VariableZoom(0, cameraParameters.maxZoom) else Zoom.FixedZoom
     }
 
     /**

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/SupportedParameters.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/SupportedParameters.kt
@@ -56,6 +56,13 @@ internal class SupportedParameters(
     }
 
     /**
+     * @see Camera.Parameters.getMaxZoom
+     */
+    val maxSupportedZoom by lazy {
+        cameraParameters.maxZoom
+    }
+
+    /**
      * @see Camera.Parameters.isZoomSupported
      */
     val supportedZoom by lazy {

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/Zoom.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/Zoom.kt
@@ -1,0 +1,12 @@
+package io.fotoapparat.parameter
+
+/**
+ * Zoom modes which camera can use.
+ */
+sealed class Zoom {
+
+    object FixedZoom : Zoom()
+
+    data class VariableZoom(val minZoom: Int, val maxZoom: Int) : Zoom()
+
+}

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/Zoom.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/Zoom.kt
@@ -1,12 +1,18 @@
 package io.fotoapparat.parameter
 
 /**
- * Zoom modes which camera can use.
+ * Zoom modes which camera can have.
  */
 sealed class Zoom {
 
+    /**
+     * The camera can only support one, fixed zoom level.
+     */
     object FixedZoom : Zoom()
 
-    data class VariableZoom(val minZoom: Int, val maxZoom: Int) : Zoom()
+    /**
+     * The camera can only support a variable zoom level between (and including) 0 and [maxZoom] values.
+     */
+    data class VariableZoom(val maxZoom: Int) : Zoom()
 
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/routine/zoom/UpdateZoomLevelRoutine.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/routine/zoom/UpdateZoomLevelRoutine.kt
@@ -3,6 +3,7 @@ package io.fotoapparat.routine.zoom
 import android.support.annotation.FloatRange
 import io.fotoapparat.exception.LevelOutOfRangeException
 import io.fotoapparat.hardware.Device
+import io.fotoapparat.parameter.Zoom
 import kotlinx.coroutines.experimental.runBlocking
 
 
@@ -17,7 +18,7 @@ internal fun Device.updateZoomLevel(
     zoomLevel.ensureInBounds()
     val cameraDevice = awaitSelectedCamera()
 
-    if (cameraDevice.getCapabilities().canZoom) {
+    if (cameraDevice.getCapabilities().zoom is Zoom.VariableZoom) {
         cameraDevice.setZoom(zoomLevel)
     }
 }

--- a/fotoapparat/src/test/java/io/fotoapparat/parameter/camera/provide/CameraParametersProviderTest.kt
+++ b/fotoapparat/src/test/java/io/fotoapparat/parameter/camera/provide/CameraParametersProviderTest.kt
@@ -21,8 +21,7 @@ internal class CameraParametersProviderTest {
     val iso = 100
 
     val capabilities = Capabilities(
-            canZoom = false,
-            maxZoom = 3,
+            zoom = Zoom.FixedZoom,
             flashModes = setOf(Flash.AutoRedEye),
             focusModes = setOf(FocusMode.Fixed),
             canSmoothZoom = false,

--- a/fotoapparat/src/test/java/io/fotoapparat/parameter/camera/provide/CameraParametersProviderTest.kt
+++ b/fotoapparat/src/test/java/io/fotoapparat/parameter/camera/provide/CameraParametersProviderTest.kt
@@ -22,6 +22,7 @@ internal class CameraParametersProviderTest {
 
     val capabilities = Capabilities(
             canZoom = false,
+            maxZoom = 3,
             flashModes = setOf(Flash.AutoRedEye),
             focusModes = setOf(FocusMode.Fixed),
             canSmoothZoom = false,

--- a/fotoapparat/src/test/java/io/fotoapparat/routine/zoom/UpdateZoomLevelRoutineTest.kt
+++ b/fotoapparat/src/test/java/io/fotoapparat/routine/zoom/UpdateZoomLevelRoutineTest.kt
@@ -46,7 +46,7 @@ internal class UpdateZoomLevelRoutineTest {
         // Given
         device.awaitSelectedCamera() willReturn cameraDevice
         cameraDevice.getCapabilities() willReturn testCapabilities.copy(
-                zoom = Zoom.VariableZoom(0, 3)
+                zoom = Zoom.VariableZoom(3)
         )
 
         // When

--- a/fotoapparat/src/test/java/io/fotoapparat/routine/zoom/UpdateZoomLevelRoutineTest.kt
+++ b/fotoapparat/src/test/java/io/fotoapparat/routine/zoom/UpdateZoomLevelRoutineTest.kt
@@ -3,6 +3,7 @@ package io.fotoapparat.routine.zoom
 import io.fotoapparat.exception.LevelOutOfRangeException
 import io.fotoapparat.hardware.CameraDevice
 import io.fotoapparat.hardware.Device
+import io.fotoapparat.parameter.Zoom
 import io.fotoapparat.test.testCapabilities
 import io.fotoapparat.test.willReturn
 import kotlinx.coroutines.experimental.runBlocking
@@ -45,7 +46,7 @@ internal class UpdateZoomLevelRoutineTest {
         // Given
         device.awaitSelectedCamera() willReturn cameraDevice
         cameraDevice.getCapabilities() willReturn testCapabilities.copy(
-                canZoom = true
+                zoom = Zoom.VariableZoom(0, 3)
         )
 
         // When
@@ -60,7 +61,7 @@ internal class UpdateZoomLevelRoutineTest {
         // Given
         device.awaitSelectedCamera() willReturn cameraDevice
         cameraDevice.getCapabilities() willReturn testCapabilities.copy(
-                canZoom = false
+                zoom = Zoom.FixedZoom
         )
 
         // When

--- a/fotoapparat/src/test/java/io/fotoapparat/test/TestObjectFactory.kt
+++ b/fotoapparat/src/test/java/io/fotoapparat/test/TestObjectFactory.kt
@@ -49,7 +49,7 @@ internal val testConfiguration = CameraConfiguration(
  * Test object for [Capabilities].
  */
 val testCapabilities = Capabilities(
-        zoom = Zoom.VariableZoom(0, 3),
+        zoom = Zoom.VariableZoom(3),
         flashModes = setOf(Flash.AutoRedEye),
         focusModes = setOf(FocusMode.Fixed),
         canSmoothZoom = false,

--- a/fotoapparat/src/test/java/io/fotoapparat/test/TestObjectFactory.kt
+++ b/fotoapparat/src/test/java/io/fotoapparat/test/TestObjectFactory.kt
@@ -4,7 +4,6 @@ import io.fotoapparat.capability.Capabilities
 import io.fotoapparat.configuration.CameraConfiguration
 import io.fotoapparat.parameter.*
 import io.fotoapparat.parameter.camera.CameraParameters
-import io.fotoapparat.preview.Frame
 import io.fotoapparat.selector.single
 import io.fotoapparat.util.FrameProcessor
 
@@ -50,8 +49,7 @@ internal val testConfiguration = CameraConfiguration(
  * Test object for [Capabilities].
  */
 val testCapabilities = Capabilities(
-        canZoom = false,
-        maxZoom = 3,
+        zoom = Zoom.VariableZoom(0, 3),
         flashModes = setOf(Flash.AutoRedEye),
         focusModes = setOf(FocusMode.Fixed),
         canSmoothZoom = false,

--- a/fotoapparat/src/test/java/io/fotoapparat/test/TestObjectFactory.kt
+++ b/fotoapparat/src/test/java/io/fotoapparat/test/TestObjectFactory.kt
@@ -51,6 +51,7 @@ internal val testConfiguration = CameraConfiguration(
  */
 val testCapabilities = Capabilities(
         canZoom = false,
+        maxZoom = 3,
         flashModes = setOf(Flash.AutoRedEye),
         focusModes = setOf(FocusMode.Fixed),
         canSmoothZoom = false,

--- a/sample/src/main/java/io/fotoapparat/sample/MainActivity.kt
+++ b/sample/src/main/java/io/fotoapparat/sample/MainActivity.kt
@@ -12,6 +12,7 @@ import io.fotoapparat.configuration.CameraConfiguration
 import io.fotoapparat.configuration.UpdateConfiguration
 import io.fotoapparat.log.logcat
 import io.fotoapparat.parameter.Flash
+import io.fotoapparat.parameter.Zoom
 import io.fotoapparat.result.transformer.scaled
 import io.fotoapparat.selector.*
 import kotlinx.android.synthetic.main.activity_main.*
@@ -153,7 +154,7 @@ class MainActivity : AppCompatActivity() {
                 .whenAvailable { capabilities ->
                     capabilities
                             ?.let {
-                                zoomSeekBar.visibility = if (it.canZoom) View.VISIBLE else View.GONE
+                                zoomSeekBar.visibility = if (it.zoom is Zoom.VariableZoom) View.VISIBLE else View.GONE
                                 torchSwitch.visibility = if (it.flashModes.contains(Flash.Torch)) View.VISIBLE else View.GONE
                             }
                             ?: Log.e(LOGGING_TAG, "Couldn't obtain capabilities.")


### PR DESCRIPTION
Hello, guys!

I think it will be useful if you add "maxZoom" value into camera capabilities. Little use-case: you want to create pinch-zoom camera view, and you need max zoom level value for correct zoom step value calculations according to fingers travelling distance calculations.