### PR TITLE
README: Update JitPack dependencies to match new naming scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ repositories {
   maven { url 'https://jitpack.io' }
 }
  
-implementation 'io.fotoapparat.fotoapparat:library:2.2.0'
+implementation 'com.github.Fotoapparat.Fotoapparat:library:2.2.0'
 ```
 
 Camera permission will be automatically added to your `AndroidManifest.xml`. Do not forget to request this permission on Marshmallow and higher.
@@ -177,7 +177,7 @@ If you like to test and try the latest added features & bugfixes you can use the
 Gradle will download & cache the latest snapshot version, so be sure to delete the cache if you want to try a newer `snapshot` version than the downloaded/cached one.
 
 ```groovy
-implementation 'io.fotoapparat:fotoapparat:-SNAPSHOT'
+implementation 'com.github.Fotoapparat:Fotoapparat:master-SNAPSHOT'
 ```
 
 ## Face detection


### PR DESCRIPTION
It seems, like something has changed on JitPack and the mentioned
references didn't work anymore.

Signed-off-by: Petr Štetiar <ynezz@true.cz>