### PR TITLE
Add special handling for external lens positions (Fixes #224)

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/characteristic/LensPositionCharacteristic.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/characteristic/LensPositionCharacteristic.kt
@@ -6,6 +6,11 @@ import android.hardware.Camera
 import io.fotoapparat.exception.camera.CameraException
 
 /**
+ * On some devices with double cameras v1 still returns external lens position (as in v2).
+ */
+private const val CAMERA_FACING_EXTERNAL = 2
+
+/**
  * Maps between [LensPosition] and Camera v1 lens position code id.
  *
  * @receiver Camera facing info id.
@@ -16,6 +21,7 @@ internal fun Int.toLensPosition(): LensPosition =
         when (this) {
             Camera.CameraInfo.CAMERA_FACING_FRONT -> LensPosition.Front
             Camera.CameraInfo.CAMERA_FACING_BACK -> LensPosition.Back
+            CAMERA_FACING_EXTERNAL -> LensPosition.External
             else -> throw IllegalArgumentException("Lens position $this is not supported.")
         }
 


### PR DESCRIPTION
Added case for `lensPosition==2`. Fixes exception on some rare devices with incorrect camera API implementation. 