### PR TITLE
Add TopCrop option to ScaleType

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/ScaleType.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/ScaleType.kt
@@ -15,6 +15,13 @@ enum class ScaleType {
      * The preview will be scaled so as its one dimensions will be equal and the other one equal or
      * smaller than the corresponding dimension of the view
      */
-    CenterInside
+    CenterInside,
+
+
+    /**
+     * The preview will be scaled so as its one dimensions will be equal and the other one equal or
+     * larger than the corresponding dimension of the view with focus on the top part
+     */
+    TopCrop,
 
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/view/CameraView.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/view/CameraView.kt
@@ -82,6 +82,7 @@ private fun ViewGroup.layoutTextureView(
 ) = when (scaleType) {
     ScaleType.CenterInside -> previewResolution?.centerInside(this)
     ScaleType.CenterCrop -> previewResolution?.centerCrop(this)
+    ScaleType.TopCrop -> previewResolution?.topCrop(this)
     else -> null
 }
 
@@ -128,6 +129,28 @@ private fun Resolution.centerCrop(view: ViewGroup) {
 
     view.layoutChildrenAt(rect)
 }
+
+private fun Resolution.topCrop(view: ViewGroup) {
+    val scale = Math.max(
+            view.measuredWidth / width.toFloat(),
+            view.measuredHeight / height.toFloat()
+    )
+
+    val width = (width * scale).toInt()
+    val height = (height * scale).toInt()
+
+    val extraX = Math.max(0, width - view.measuredWidth)
+
+    val rect = Rect(
+            -extraX / 2,
+            0,
+            width - extraX / 2,
+            height
+    )
+
+    view.layoutChildrenAt(rect)
+}
+
 
 private fun ViewGroup.layoutChildrenAt(rect: Rect) {
     (0 until childCount).forEach {


### PR DESCRIPTION
Add the ability to make `TopCrop` in `ScaleType`.

`TopCrop` will work the same as `CenterCrop` in full mode when the `CameraView` hight = "match_parent"

But when the user decided to show half of the camera for example if hight = "300dp",
the `CenterCrop` will show the center part of the camera while the `TopCrop` will show the top part.
